### PR TITLE
Bounds of geometry column

### DIFF
--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -1,13 +1,20 @@
 use std::sync::Arc;
 
 use crate::util::iter_geom;
-use arrow2::array::{ArrayRef, BinaryArray, MutableBinaryArray};
+use arrow2::{
+    array::{
+        ArrayRef, BinaryArray, FixedSizeListArray, MutableBinaryArray,
+        MutableFixedSizeListArray, MutablePrimitiveArray, TryExtend,
+    },
+};
 use geo::Geometry;
 use geozero::{CoordDimensions, ToWkb};
 use polars::prelude::{Result, Series};
 
 pub trait GeoSeries {
     fn area(&self) -> Result<Series>;
+
+    fn bounds(&self) -> Result<Series>;
 
     fn centroid(&self) -> Result<Series>;
 }
@@ -19,6 +26,28 @@ impl GeoSeries for Series {
         let output_series: Series = iter_geom(self).map(|geom| geom.unsigned_area()).collect();
 
         Ok(output_series)
+    }
+
+    fn bounds(&self) -> Result<Series> {
+        use geo::algorithm::bounding_rect::BoundingRect;
+
+        let mut output_vec: Vec<Option<Vec<Option<f64>>>> = Vec::with_capacity(self.len() * 4);
+
+        for geom in iter_geom(self) {
+            let value = geom.bounding_rect().expect("could not create centroid");
+            let mut item: Vec<Option<f64>> = Vec::with_capacity(4);
+            item.push(Some(value.min().x));
+            item.push(Some(value.min().y));
+            item.push(Some(value.max().x));
+            item.push(Some(value.max().y));
+            output_vec.push(Some(item));
+        }
+
+        let mut list = MutableFixedSizeListArray::new(MutablePrimitiveArray::<f64>::new(), 4);
+        list.try_extend(output_vec).unwrap();
+        let list: FixedSizeListArray = list.into();
+
+        Series::try_from(("result", Arc::new(list) as ArrayRef))
     }
 
     fn centroid(&self) -> Result<Series> {

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -34,7 +34,7 @@ impl GeoSeries for Series {
         let mut output_vec: Vec<Option<Vec<Option<f64>>>> = Vec::with_capacity(self.len() * 4);
 
         for geom in iter_geom(self) {
-            let value = geom.bounding_rect().expect("could not create centroid");
+            let value = geom.bounding_rect().expect("could not compute bounds");
             let mut item: Vec<Option<f64>> = Vec::with_capacity(4);
             item.push(Some(value.min().x));
             item.push(Some(value.min().y));

--- a/geopolars/src/main.rs
+++ b/geopolars/src/main.rs
@@ -26,6 +26,9 @@ fn main() -> Result<()> {
     println!("{}", df);
 
     let start = Instant::now();
+    let bounds = df.column("geometry")?.bounds()?;
+    println!("{}", bounds);
+
     let _ = df.centroid()?;
     let _ = df.column("geometry")?.centroid()?;
     println!("Debug: {}", start.elapsed().as_secs_f32());


### PR DESCRIPTION
This doesn't work because Polars doesn't support `FixedSizeListArray`
```
Error: InvalidOperation("Cannot create polars series from FixedSizeList(Field { name: \"item\", data_type: Float64, is_nullable: true, metadata: {} }, 4) type")
```

Regardless, I'm not sure the best way to be constructing these columns