### PR TITLE
Fix python example, return GeoSeries from get_column

### DIFF
--- a/py-geopolars/example.py
+++ b/py-geopolars/example.py
@@ -1,12 +1,9 @@
-import polars as pl
 import pyarrow as pa
+import geopolars as gpl
 
-from geopolars import centroid
-
-reader = pa.ipc.open_file("../cities.arrow")
+reader = pa.ipc.open_file("../data/cities.arrow")
 table = reader.read_all()
 
-df = pl.from_arrow(table)
-geom = df.get_column("geometry")
-out = centroid(geom)
+df = gpl.from_arrow(table)
+out = df.geometry.centroid()
 print(out)

--- a/py-geopolars/example.py
+++ b/py-geopolars/example.py
@@ -1,9 +1,11 @@
 import pyarrow as pa
+
 import geopolars as gpl
 
 reader = pa.ipc.open_file("../data/cities.arrow")
 table = reader.read_all()
 
 df = gpl.from_arrow(table)
-out = df.geometry.centroid()
+geom = df.get_column("geometry")
+out = geom.centroid()
 print(out)

--- a/py-geopolars/python/geopolars/internals/geodataframe.py
+++ b/py-geopolars/python/geopolars/internals/geodataframe.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from polars import DataFrame
+import polars as pl
 
 from geopolars import geopolars as core  # type: ignore
 from geopolars.internals.geoseries import GeoSeries
@@ -8,18 +8,45 @@ from geopolars.internals.geoseries import GeoSeries
 DEFAULT_GEO_COLUMN_NAME = "geometry"
 
 
-class GeoDataFrame(DataFrame):
+class GeoDataFrame(pl.DataFrame):
 
     _geometry_column_name = DEFAULT_GEO_COLUMN_NAME
 
     def __init__(self, data=None, columns=None, orient=None, *, geometry=None):
 
         # Wrap an existing polars DataFrame
-        if isinstance(data, DataFrame):
+        if isinstance(data, pl.DataFrame):
             self._df = data._df
             return
 
         super().__init__(data, columns, orient)
+
+    def get_column(self, name: str) -> pl.Series | GeoSeries:
+        """
+        Get a single column as Series or GeoSeries by name. Return GeoSeries if requested column is geometry column.
+
+        Parameters
+        ----------
+        name : str
+            Name of the column to retrieve.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
+        >>> df.get_column("foo")
+        shape: (3,)
+        Series: 'foo' [i64]
+        [
+                1
+                2
+                3
+        ]
+
+        """
+        series = super().get_column(name)
+        if name == self._geometry_column_name:
+            series = GeoSeries(series)
+        return series
 
     @property
     def geometry(self):

--- a/py-geopolars/python/geopolars/internals/geodataframe.py
+++ b/py-geopolars/python/geopolars/internals/geodataframe.py
@@ -1,18 +1,21 @@
-import polars
+from __future__ import annotations
 
+from polars import DataFrame
+
+from geopolars import geopolars as core  # type: ignore
 from geopolars.internals.geoseries import GeoSeries
 
 DEFAULT_GEO_COLUMN_NAME = "geometry"
 
 
-class GeoDataFrame(polars.DataFrame):
+class GeoDataFrame(DataFrame):
 
     _geometry_column_name = DEFAULT_GEO_COLUMN_NAME
 
     def __init__(self, data=None, columns=None, orient=None, *, geometry=None):
 
         # Wrap an existing polars DataFrame
-        if isinstance(data, polars.DataFrame):
+        if isinstance(data, DataFrame):
             self._df = data._df
             return
 

--- a/py-geopolars/src/api.rs
+++ b/py-geopolars/src/api.rs
@@ -1,4 +1,4 @@
-use crate::geefoseries;
+use crate::geoseries;
 use pyo3::prelude::*;
 
 #[pymodule]

--- a/py-geopolars/src/api.rs
+++ b/py-geopolars/src/api.rs
@@ -1,4 +1,4 @@
-use crate::geoseries;
+use crate::geefoseries;
 use pyo3::prelude::*;
 
 #[pymodule]


### PR DESCRIPTION
This PR adresses two things
- Fix example.py as this wasn't working. Now it returns correct centroid of dataframe. Previously it failed on import because centroid is a method on GeoSeries.
- GeoSeries.get_column("geometry") was returning Series instead of GeoSeries. This pr modify get_column to return GeoSeries when requested column is geo column