### PR TITLE
chore(python): build arm64 wheels instead of universal2

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -3,8 +3,8 @@ name: Build Python Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    # tags:
-    #   - "v*"
+    tags:
+      - "v*"
 
 jobs:
   build_wheels:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -3,8 +3,8 @@ name: Build Python Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    tags:
-      - "v*"
+    # tags:
+    #   - "v*"
 
 jobs:
   build_wheels:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -20,11 +20,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.0
         env:
-          # Python wheel support for mac M1 started as of 3.8. So if we _only_ build universal2
-          # wheels, we don't build a wheel for 3.7. Therefore, we set CIBW_ARCHS_MACOS to both, but
-          # explicitly skip x86-64-only wheels for 3.8 and higher.
-          CIBW_SKIP: "cp2* cp35* cp36* cp38*macosx*x86_64 cp39*macosx*x86_64 cp310*macosx*x86_64 pp* *win32 *i686 *musllinux*"
-          CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_SKIP: "cp2* cp35* cp36* pp* *win32 *i686 *musllinux*"
+          CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
           CIBW_BEFORE_ALL: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y"
           CIBW_BEFORE_ALL_MACOS: "rustup target add aarch64-apple-darwin"


### PR DESCRIPTION
Originally I thought there was a bug in maturin that incorrectly used the x86 name when building arm64 wheels, but it appears that bug is gone now. Building x86 and arm wheels separately means that more files are produced, but each one is half the size.