### PR TITLE
Implement `explode_geometries` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,7 +144,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 2.34.0",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -169,18 +175,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -264,6 +258,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,9 +305,30 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+dependencies = [
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap 0.15.1",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -333,15 +375,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
- "clap",
+ "ciborium",
+ "clap 3.2.22",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -350,7 +393,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -359,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -447,19 +489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -760,12 +789,6 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1137,6 +1160,12 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking_lot"
@@ -1547,12 +1576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,16 +1716,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,7 +1732,7 @@ version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1877,6 +1890,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/geopolars/Cargo.toml
+++ b/geopolars/Cargo.toml
@@ -52,3 +52,7 @@ bench = false
 [[bench]]
 name = "affine"
 harness = false
+
+[[bench]]
+name = "explode"
+harness = false

--- a/geopolars/benches/explode.rs
+++ b/geopolars/benches/explode.rs
@@ -1,0 +1,30 @@
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use geo::Geometry;
+use geo::MultiPoint;
+use geo::Point;
+use geopolars::error::Result;
+use geopolars::geoseries::GeoSeries;
+use polars::prelude::*;
+
+fn generate_multipoint_series() -> Result<Series> {
+    let points: Vec<Point> = (0..90_000).map(|_| Point::new(0., 0.)).collect();
+    let multipoints: Vec<Geometry> = points
+        .chunks(2)
+        .map(|points| MultiPoint::new(points.to_vec()))
+        .map(Geometry::MultiPoint)
+        .collect();
+    let series = Series::from_geom_vec(&multipoints).unwrap();
+    Ok(series)
+}
+
+fn bench_explode(b: &mut Bencher) {
+    let series = generate_multipoint_series().expect("Unable to generate multipoint series");
+    b.iter(|| GeoSeries::explode(&series))
+}
+
+fn explode_benchmark(c: &mut Criterion) {
+    c.bench_function("explode", bench_explode);
+}
+
+criterion_group!(benches, explode_benchmark);
+criterion_main!(benches);

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -71,7 +71,7 @@ pub trait GeoSeries {
     fn exterior(&self) -> Result<Series>;
 
     /// Explodes multi-part geometries into multiple single geometries.
-    fn explode_geometries(&self) -> Result<Series>;
+    fn explode(&self) -> Result<Series>;
 
     /// Create a Series from a vector of geometries
     fn from_geom_vec(geoms: &[Geometry<f64>]) -> Result<Series>;
@@ -310,7 +310,7 @@ impl GeoSeries for Series {
         Ok(series)
     }
 
-    fn explode_geometries(&self) -> Result<Series> {
+    fn explode(&self) -> Result<Series> {
         let mut exploded_vector = Vec::new();
 
         for geometry in iter_geom(self) {
@@ -1002,7 +1002,7 @@ mod tests {
         assert_eq!(10.0_f64, as_vec[0]);
     }
     #[test]
-    fn explode_geometries() {
+    fn explode() {
         let point_0 = Point::new(0., 0.);
         let point_1 = Point::new(1., 1.);
         let point_2 = Point::new(2., 2.);
@@ -1027,7 +1027,7 @@ mod tests {
         ])
         .unwrap();
 
-        let output_series = input_series.explode_geometries().unwrap();
+        let output_series = GeoSeries::explode(&input_series).unwrap();
 
         assert_eq!(output_series, expected_series);
     }

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -311,7 +311,7 @@ impl GeoSeries for Series {
     }
 
     fn explode_geometries(&self) -> Result<Series> {
-        let mut exploded_vector = vec![];
+        let mut exploded_vector = Vec::new();
 
         for geometry in iter_geom(self) {
             match geometry {

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -311,55 +311,57 @@ impl GeoSeries for Series {
     }
 
     fn explode_geometries(&self) -> Result<Series> {
-        let mut nested_vector = vec![];
+        let mut exploded_vector = vec![];
 
         for geometry in iter_geom(self) {
             match geometry {
                 Geometry::Point(geometry) => {
-                    let point = vec![Geometry::Point(geometry)];
-                    nested_vector.push(point)
+                    let point = Geometry::Point(geometry);
+                    exploded_vector.push(point)
                 }
                 Geometry::MultiPoint(geometry) => {
-                    let points: Vec<Geometry> = geometry.into_iter().map(Geometry::Point).collect();
-                    nested_vector.push(points)
+                    for geom in geometry.into_iter() {
+                        let point = Geometry::Point(geom);
+                        exploded_vector.push(point)
+                    }
                 }
                 Geometry::Line(geometry) => {
-                    let line = vec![Geometry::Line(geometry)];
-                    nested_vector.push(line)
+                    let line = Geometry::Line(geometry);
+                    exploded_vector.push(line)
                 }
                 Geometry::LineString(geometry) => {
-                    let line_string = vec![Geometry::LineString(geometry)];
-                    nested_vector.push(line_string)
+                    let line_string = Geometry::LineString(geometry);
+                    exploded_vector.push(line_string)
                 }
                 Geometry::MultiLineString(geometry) => {
-                    let line_strings: Vec<Geometry> =
-                        geometry.into_iter().map(Geometry::LineString).collect();
-                    nested_vector.push(line_strings)
+                    for geom in geometry.into_iter() {
+                        let line_string = Geometry::LineString(geom);
+                        exploded_vector.push(line_string)
+                    }
                 }
                 Geometry::Polygon(geometry) => {
-                    let polygon = vec![Geometry::Polygon(geometry)];
-                    nested_vector.push(polygon)
+                    let polygon = Geometry::Polygon(geometry);
+                    exploded_vector.push(polygon)
                 }
                 Geometry::MultiPolygon(geometry) => {
-                    let polygons: Vec<Geometry> =
-                        geometry.into_iter().map(Geometry::Polygon).collect();
-                    nested_vector.push(polygons)
+                    for geom in geometry.into_iter() {
+                        let polygon = Geometry::Polygon(geom);
+                        exploded_vector.push(polygon)
+                    }
                 }
                 Geometry::Rect(geometry) => {
-                    let rectangle = vec![Geometry::Rect(geometry)];
-                    nested_vector.push(rectangle)
+                    let rectangle = Geometry::Rect(geometry);
+                    exploded_vector.push(rectangle)
                 }
                 Geometry::Triangle(geometry) => {
-                    let triangle = vec![Geometry::Triangle(geometry)];
-                    nested_vector.push(triangle)
+                    let triangle = Geometry::Triangle(geometry);
+                    exploded_vector.push(triangle)
                 }
                 _ => unimplemented!(),
             };
         }
 
-        let flattened_vector: Vec<Geometry> = nested_vector.into_iter().flatten().collect();
-
-        let exploded_series = Series::from_geom_vec(&flattened_vector)?;
+        let exploded_series = Series::from_geom_vec(&exploded_vector)?;
 
         Ok(exploded_series)
     }


### PR DESCRIPTION
Closes #26 by implementing an `explode_geometries` method that takes a `GeoSeries` with multipart geometries and return a `GeoSeries` with those geometries split into multiple individual geometries.

I've taken the approach suggested in the original issue, of iterating through the geometries and appending them to a new series.

I've added a test cribbed from the `geopandas` example to prove this works and a very minimal docstring, also copied from `geopandas`.

A few things to note:

- I went with `explode_geometries` instead of `explode` because when I used `explode` I was just getting the `polars` method of the same name. This is probably just ignorance on my part!
- I'm not handling  `Geometry::GeometryCollection` because I wasn't sure if I should be but I could do this recursively, if I abstract the match expression into a function.
- My naming conversions are a little more verbose than yours (e.g. `geometry` instead of `geom`) but I'd be happy to conform if needed

For what it's worth, If I was going to implement this for your `GeoDataFrame`, I'd probably duplicate the other information and add a "geometry index" `Series` with the index of the geometry within the original multipart geometry.