### PR TITLE
WIP: multithreading support

### DIFF
--- a/geopolars/src/util.rs
+++ b/geopolars/src/util.rs
@@ -17,6 +17,14 @@ pub(crate) fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> 
     })
 }
 
+// Parse a u8 series representing a single WKB geometry to a Geometry object
+pub(crate) fn parse_u8_series_to_geom(row: &Series) -> Result<Geometry> {
+    let buffer = row.u8()?;
+    let vec = buffer.cont_slice()?.to_vec();
+    let geom = Wkb(vec).to_geo().expect("unable to convert geo");
+    Ok(geom)
+}
+
 /// Access to a geometry at a specified index
 pub(crate) fn geom_at_index(series: &Series, index: usize) -> Result<Geometry<f64>> {
     let item_at_index = match series.get(index) {


### PR DESCRIPTION
An absolutely massive performance improvement (at least for wall time), and shows that it's not hard to parallelize functions by row

```py
import geopolars as gpl
import polars as pl
gs = gpl.datasets.read_dataset('nybb').get_column('geometry')
# Concat 1000 times for a larger series
gs_larger = gpl.GeoSeries(pl.concat(1000* [gs]))

%time gs_larger.area
```

With `master`:
```
CPU times: user 9.94 s, sys: 35 ms, total: 9.98 s
Wall time: 9.98 s
```

With this branch:
```
CPU times: user 10.4 s, sys: 145 ms, total: 10.6 s
Wall time: 763 ms
```

With geopandas:
```
CPU times: user 719 ms, sys: 15.2 ms, total: 734 ms
Wall time: 750 ms
```

Lessons learned:

- Having to copy arrow data into a vec, parse that wkb `vec<u8>` into a geometry, then copy it back into a wkb is atrocious for performance. We already knew that but this puts real numbers to it
- This is still 14x slower than geopandas when you consider cpu time, but we have huge performance gains still possible by avoiding copies
- Can't wait to look at geoarrow encoding + traits