### PR TITLE
chore, development: Set vscode window colors by language color

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#e9c2ac",
+        "activityBar.background": "#e9c2ac",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#289750",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#15202b99",
+        "sash.hoverBorder": "#e9c2ac",
+        "statusBar.background": "#dea584",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#d3885c",
+        "statusBarItem.remoteBackground": "#dea584",
+        "statusBarItem.remoteForeground": "#15202b",
+        "titleBar.activeBackground": "#dea584",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#dea58499",
+        "titleBar.inactiveForeground": "#15202b99"
+    },
+    "peacock.color": "#dea584"
+}

--- a/py-geopolars/.vscode/settings.json
+++ b/py-geopolars/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#498cc4",
+        "activityBar.background": "#498cc4",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#e8b7d1",
+        "activityBarBadge.foreground": "#15202b",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#498cc4",
+        "statusBar.background": "#3572a5",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#498cc4",
+        "statusBarItem.remoteBackground": "#3572a5",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#3572a5",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#3572a599",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#3572A5"
+}

--- a/wasm-geopolars/.vscode/settings.json
+++ b/wasm-geopolars/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "peacock.color": "#f1e05a",
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#f5e989",
+        "activityBar.background": "#f5e989",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#0fb09e",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#15202b99",
+        "sash.hoverBorder": "#f5e989",
+        "statusBar.background": "#f1e05a",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#edd72b",
+        "statusBarItem.remoteBackground": "#f1e05a",
+        "statusBarItem.remoteForeground": "#15202b",
+        "titleBar.activeBackground": "#f1e05a",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#f1e05a99",
+        "titleBar.inactiveForeground": "#15202b99"
+    }
+}


### PR DESCRIPTION
Store project-specific vscode settings for the [peacock](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock) plugin so that the language/plugin context is derived. Uses https://github.com/ozh/github-colors/blob/master/colors.json, so Rust, Python, and JS are reflected as a github citizen would expect

![image](https://user-images.githubusercontent.com/15164633/195958564-ab0e45ed-817c-4728-b411-2eafec23d82d.png)
![image](https://user-images.githubusercontent.com/15164633/195958568-551161bf-a6ca-4264-bc48-b4fcf4dcf436.png)
![image](https://user-images.githubusercontent.com/15164633/195958572-8f949ecd-8dc4-4b4e-bd1b-d6be4d2b0bed.png)
