### PR TITLE
pin polars to 0.14.18

### DIFF
--- a/py-geopolars/pyproject.toml
+++ b/py-geopolars/pyproject.toml
@@ -6,7 +6,10 @@ build-backend = "maturin"
 name = "geopolars"
 version = "0.1.0-alpha.3"
 dependencies = [
-  "polars",
+  # Polars 0.14.19 is a breaking change for us. That patch release adds BinaryArray support, which
+  # means that data conversions from PyArrow become BinaryArray instead of ListArray<u8>. See
+  # https://github.com/geopolars/geopolars/issues/122
+  "polars<=0.14.18",
   "pyarrow>=4.0.*",
   "numpy >= 1.16.0"
 ]


### PR DESCRIPTION
The new BinaryArray support is great but a breaking change for us. Issue tracked in #122 to be implemented whenever a new polars rust release is out