### PR TITLE
Drop support for 3.7

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,10 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: run pre-commit
         run: |
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.11"]
     defaults:
       run:
         working-directory: py-geopolars

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.10"]
     defaults:
       run:
         working-directory: py-geopolars

--- a/py-geopolars/build.requirements.txt
+++ b/py-geopolars/build.requirements.txt
@@ -2,7 +2,8 @@
 polars==0.14.18
 pyarrow>=4.0
 numpy>=1.16.0
-geopandas
+# temporary so that tests pass with old datasets
+geopandas<0.12
 
 # Tooling
 maturin==0.13.2

--- a/py-geopolars/pyproject.toml
+++ b/py-geopolars/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "pyarrow>=4.0.*",
   "numpy >= 1.16.0"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description = "Geospatial extensions for Polars"
 readme = "README.md"
 # Specify SPDX expression in Cargo.toml instead of here


### PR DESCRIPTION
In line with Numpy suggestions and geopandas/pyproj.

This also makes https://github.com/geopolars/geopolars/pull/148 easier, because our tests currently check for parity between the content of our datasets and what geopandas has. Geopandas updated its included datasets recently, but python 3.7 brings in an older version of geopandas with the old version of included datasets

See:

- https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule
- https://github.com/geopandas/geopandas/issues/2391
- https://github.com/geopandas/geopandas/pull/2398