### PR TITLE
Build `abi3` wheels for simplicity

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,10 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: run pre-commit
         run: |
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.11"]
     defaults:
       run:
         working-directory: py-geopolars

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.10"]
     defaults:
       run:
         working-directory: py-geopolars

--- a/py-geopolars/Cargo.toml
+++ b/py-geopolars/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 polars = "0.24"
-pyo3 = { version = "0.17.2", features = ["extension-module"] }
+pyo3 = { version = "0.17.2", features = ["abi3-py38", "extension-module"] }
 # Re-enable proj whenever we figure out how to build wheels with it
 # https://github.com/geopolars/geopolars/issues/125
 # geopolars = { path = "../geopolars", features = ["proj"] }

--- a/py-geopolars/pyproject.toml
+++ b/py-geopolars/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "pyarrow>=4.0.*",
   "numpy >= 1.16.0"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description = "Geospatial extensions for Polars"
 readme = "README.md"
 # Specify SPDX expression in Cargo.toml instead of here


### PR DESCRIPTION
This PR turns on [`abi3` support in pyo3](https://pyo3.rs/v0.17.2/building_and_distribution.html#py_limited_apiabi3), which means that we only need to build one wheel per platform (!!). That should be easier to manage and allow faster wheel building on CI.

a little (unscientific) perf testing on this below seems to show that there's no obvious difference in perf between python-version-specific wheels and abi3 wheels. This aligns with the hypothesis in https://github.com/pola-rs/polars/issues/5049#issuecomment-1263855313 that `abi3` should be ok because very little rust is actually touching the python api

### This branch

```
maturin build --release
pyenv local 3.10.8
python -m venv env_310
source ./env_310/bin/activate
pip install ./target/wheels/geopolars-0.1.0a3-cp38-abi3-macosx_10_7_x86_64.whl
pip install ipython
./env_310/bin/ipython
```

```py
In [1]: import geopolars as gpl
   ...: import polars as pl
   ...:

In [2]: gs = gpl.datasets.read_dataset('nybb').get_column('geometry')
   ...:

In [3]: %time gs_larger = gpl.GeoSeries(pl.concat(1000* [gs]))
CPU times: user 707 ms, sys: 670 ms, total: 1.38 s
Wall time: 1.4 s
# always between 1.3-1.4s

In [4]: %time gs_larger.area
   ...:
CPU times: user 10.5 s, sys: 81.4 ms, total: 10.6 s
Wall time: 10.7 s
# 9.93s, 9.88s, 9.79s
```

### Master

```
maturin build --release
python -m venv env_310
source ./env_310/bin/activate
pip install ./target/wheels/geopolars-0.1.0a3-cp310-cp310-macosx_10_7_x86_64.whl
pip install ipython
./env_310/bin/ipython
```

```py

In [4]: %time gs_larger = gpl.GeoSeries(pl.concat(1000* [gs]))
CPU times: user 692 ms, sys: 654 ms, total: 1.35 s
Wall time: 1.38 s

In [9]: %timeit gs_larger = gpl.GeoSeries(pl.concat(1000* [gs]))
1.25 s ± 38.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [10]: %time gs_larger.area
CPU times: user 10.1 s, sys: 496 ms, total: 10.6 s
Wall time: 11 s
# 10s, 9.82s
```
