### PR TITLE
Bundle proj data into the python wheels

### DIFF
--- a/geopolars/Cargo.toml
+++ b/geopolars/Cargo.toml
@@ -40,7 +40,6 @@ thiserror = "1.0"
 
 proj = { version = "0.27.0", optional = true, features = [
   "geo-types",
-  "bundled_proj",
 ] }
 
 [dev-dependencies]

--- a/geopolars/Cargo.toml
+++ b/geopolars/Cargo.toml
@@ -23,6 +23,7 @@ default = [
 ]
 
 proj = ["dep:proj"]
+bundled_proj = ["proj", "proj/bundled_proj"]
 
 [dependencies]
 geozero = { version = "0.9.4", features = ["with-wkb"] }

--- a/geopolars/src/export.rs
+++ b/geopolars/src/export.rs
@@ -1,3 +1,2 @@
-
 #[cfg(feature = "proj")]
 pub use proj;

--- a/geopolars/src/export.rs
+++ b/geopolars/src/export.rs
@@ -1,0 +1,3 @@
+
+#[cfg(feature = "proj")]
+pub use proj;

--- a/geopolars/src/lib.rs
+++ b/geopolars/src/lib.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod geodataframe;
 pub mod geoseries;
 pub mod spatial_index;
+pub mod export;
 mod util;
 
 #[cfg(test)]

--- a/geopolars/src/lib.rs
+++ b/geopolars/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod error;
+pub mod export;
 pub mod geodataframe;
 pub mod geoseries;
 pub mod spatial_index;
-pub mod export;
 mod util;
 
 #[cfg(test)]

--- a/py-geopolars/.gitignore
+++ b/py-geopolars/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# proj data
+geopolars.data/data/proj_data/

--- a/py-geopolars/.gitignore
+++ b/py-geopolars/.gitignore
@@ -164,4 +164,4 @@ cython_debug/
 #.idea/
 
 # proj data
-geopolars.data/data/proj_data/
+python/geopolars/proj_data

--- a/py-geopolars/Makefile
+++ b/py-geopolars/Makefile
@@ -20,6 +20,7 @@ clean:  ## Clean up caches and build artifacts
 	@rm -rf .pytest_cache/
 	@rm -f .coverage
 	@rm -f coverage.xml
+	@rm -f geopolars.data/data/proj_data
 	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
 	@cargo clean
 
@@ -62,16 +63,20 @@ doctest:  ## Run doctests
 install-wheel:
 	pip install --force-reinstall -U wheels/geopolars-*.whl
 
+.PHONY: copy-proj-data
+copy-proj-data:  ## Copy PROJ data into the working tree for bundling with the wheel
+	python copy-proj-data.py
+
 .PHONY: build-no-venv
-build-no-venv:
-	maturin build -o wheels
+build-no-venv: copy-proj-data
+	maturin build -o wheels --features "proj"
 
 .PHONY: build-no-venv-release
-build-no-venv-release:
-	maturin build -o wheels --release
+build-no-venv-release: copy-proj-data
+	maturin build -o wheels --release --features "proj"
 
 .PHONY: build-and-test-no-venv
-build-and-test-no-venv:
+build-and-test-no-venv: copy-proj-data
 	maturin build -o wheels
 	pip install --force-reinstall -U wheels/geopolars-*.whl
 	pytest tests

--- a/py-geopolars/copy-proj-data.py
+++ b/py-geopolars/copy-proj-data.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import shutil
+from pathlib import Path
+
+def get_data_dir() -> str:
+    """
+    Taken and adapted from pyproj
+    """
+    def valid_data_dir(potential_data_dir):
+        if (
+                potential_data_dir is not None
+                and Path(potential_data_dir, "proj.db").exists()
+        ):
+            return True
+        return False
+
+    proj_exe = shutil.which("proj", path=sys.prefix)
+    if proj_exe is None:
+        proj_exe = shutil.which("proj")
+    if proj_exe is not None:
+        system_proj_dir = Path(proj_exe).parent.parent / "share" / "proj"
+        if valid_data_dir(system_proj_dir):
+            _VALIDATED_PROJ_DATA = str(system_proj_dir)
+
+    if _VALIDATED_PROJ_DATA is None:
+        raise Exception(
+            "Valid PROJ data directory not found. "
+            "Either set the path using the environmental variable "
+            "PROJ_DATA (PROJ 9.1+) | PROJ_LIB (PROJ<9.1) or "
+            "with `pyproj.datadir.set_data_dir`."
+        )
+    return _VALIDATED_PROJ_DATA
+
+
+def copy_proj_data():
+    data_dir = "geopolars.data/data"
+    os.makedirs(data_dir, exist_ok=True)
+    proj_data_dir = Path(data_dir) / "proj_data"
+    if proj_data_dir.exists():
+        shutil.rmtree(proj_data_dir)
+    shutil.copytree(get_data_dir(), proj_data_dir)
+
+
+copy_proj_data()

--- a/py-geopolars/copy-proj-data.py
+++ b/py-geopolars/copy-proj-data.py
@@ -34,7 +34,7 @@ def get_data_dir() -> str:
 
 
 def copy_proj_data():
-    data_dir = "geopolars.data/data"
+    data_dir = "python/geopolars"
     os.makedirs(data_dir, exist_ok=True)
     proj_data_dir = Path(data_dir) / "proj_data"
     if proj_data_dir.exists():

--- a/py-geopolars/copy-proj-data.py
+++ b/py-geopolars/copy-proj-data.py
@@ -1,6 +1,6 @@
 import os
-import sys
 import shutil
+import sys
 from pathlib import Path
 
 

--- a/py-geopolars/copy-proj-data.py
+++ b/py-geopolars/copy-proj-data.py
@@ -3,14 +3,16 @@ import sys
 import shutil
 from pathlib import Path
 
+
 def get_data_dir() -> str:
     """
     Taken and adapted from pyproj
     """
+
     def valid_data_dir(potential_data_dir):
         if (
-                potential_data_dir is not None
-                and Path(potential_data_dir, "proj.db").exists()
+            potential_data_dir is not None
+            and Path(potential_data_dir, "proj.db").exists()
         ):
             return True
         return False


### PR DESCRIPTION
This is an attempt build the python wheels with proj support by bundling the proj-data files into the wheel.

Bundling works so far, but to be able to tell proj about the location of the files ([using pythons pkg_resources](https://stackoverflow.com/questions/49773125/find-data-files-in-python3-wheel)) requires some API changes to `GeoSeries::to_crs`. In this method the transformation is constructed using the `Proj` struct, but to be able to pass in a custom data location, we would need to either pass in a `ProjBuilder` or create a custom options struct we can pass to that method. The first solution would leak proj types in the geopolars API, which currently has been avoided. The solution with the options struct may have some overheads by requiring to crate builders for each method call where the options are passed to. Thats probably no different from the current implementation, though.

@kylebarron Whats your opinion on this?