### PR TITLE
Python: add underscore to internal rust bindings

### DIFF
--- a/py-geopolars/Cargo.toml
+++ b/py-geopolars/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-name = "geopolars"
+name = "_geopolars"
 crate-type = ["cdylib"]
 
 [features]
@@ -22,3 +22,4 @@ thiserror = "1.0"
 
 [package.metadata.maturin]
 python-source = "python"
+name = "geopolars._geopolars"

--- a/py-geopolars/docs/source/reference/index.rst
+++ b/py-geopolars/docs/source/reference/index.rst
@@ -4,11 +4,7 @@ API Reference
 =============
 
 This page gives an overview of all public geopolars objects, functions and
-methods. All classes and functions exposed in ``geopolars.*`` namespace are public, except for
-``geopolars.geopolars`` which is private.
-
-.. warning::
-   The ``geopolars.geopolars`` modules is private. Stable functionality in that module is not guaranteed.
+methods. All classes and functions exposed in ``geopolars.*`` namespace are public.
 
 .. toctree::
    :maxdepth: 2

--- a/py-geopolars/python/geopolars/__init__.py
+++ b/py-geopolars/python/geopolars/__init__.py
@@ -1,5 +1,5 @@
+from geopolars._geopolars import version  # type: ignore
 from geopolars.convert import from_arrow, from_geopandas
-from geopolars.geopolars import version  # type: ignore
 from geopolars.internals.geodataframe import GeoDataFrame
 from geopolars.internals.geoseries import GeoSeries
 from geopolars.io.file import read_file

--- a/py-geopolars/python/geopolars/internals/geoseries.py
+++ b/py-geopolars/python/geopolars/internals/geoseries.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
-from geopolars import geopolars as core
+from geopolars import _geopolars as core
 from geopolars.internals.types import GeodesicMethod, TransformOrigin
 from geopolars.proj import PROJ_DATA_PATH
 

--- a/py-geopolars/src/api.rs
+++ b/py-geopolars/src/api.rs
@@ -9,7 +9,7 @@ fn version() -> &'static str {
 }
 
 #[pymodule]
-pub fn geopolars(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn _geopolars(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(geoseries::affine_transform))?;
     m.add_wrapped(wrap_pyfunction!(geoseries::area))?;
     m.add_wrapped(wrap_pyfunction!(geoseries::centroid))?;

--- a/py-geopolars/src/lib.rs
+++ b/py-geopolars/src/lib.rs
@@ -4,4 +4,4 @@ mod ffi;
 mod geoseries;
 mod utils;
 
-pub use api::geopolars;
+pub use api::_geopolars;


### PR DESCRIPTION
Taken from rtoml: https://github.com/samuelcolvin/rtoml/blob/d7647396229d1a01369bca82bec5713ff51034cb/Cargo.toml#L16

This is nice to ensure that the internal rust-python bindings are actually marked as private