### PR TITLE
Affine transform geoarrow point

### DIFF
--- a/geopolars/benches/affine.rs
+++ b/geopolars/benches/affine.rs
@@ -9,12 +9,25 @@ fn load_data() -> PolarsResult<Series> {
     // Assuming current dir is /geopolars/
     let file = File::open("../data/cities.arrow").expect("file not found");
 
-    let df = IpcReader::new(file).finish()?;
+    let df = IpcReader::new(file).memory_mapped(false).finish()?;
+    df.column("geometry").cloned()
+}
+
+fn load_struct_data() -> PolarsResult<Series> {
+    // Assuming current dir is /geopolars/
+    let file = File::open("../data/cities_struct.arrow").expect("file not found");
+
+    let df = IpcReader::new(file).memory_mapped(false).finish()?;
     df.column("geometry").cloned()
 }
 
 fn bench_translate(b: &mut Bencher) {
     let series = load_data().expect("Unable to load series");
+    b.iter(|| series.translate(10.0, 10.0))
+}
+
+fn bench_translate_geoarrow(b: &mut Bencher) {
+    let series = load_struct_data().expect("Unable to load series");
     b.iter(|| series.translate(10.0, 10.0))
 }
 
@@ -25,6 +38,7 @@ fn bench_scale(b: &mut Bencher) {
 
 fn affine_parsing_benchmark(c: &mut Criterion) {
     c.bench_function("translate", bench_translate);
+    c.bench_function("translate geoarrow", bench_translate_geoarrow);
     c.bench_function("scale", bench_scale);
 }
 

--- a/geopolars/src/geoarrow/linestring/array.rs
+++ b/geopolars/src/geoarrow/linestring/array.rs
@@ -1,5 +1,6 @@
 use geo::{Coord, LineString};
 use polars::export::arrow::array::{Array, ListArray, PrimitiveArray, StructArray};
+use polars::export::arrow::bitmap::utils::{BitmapIter, ZipValidity};
 use polars::export::arrow::bitmap::Bitmap;
 use polars::export::arrow::offset::OffsetsBuffer;
 use polars::prelude::Series;
@@ -56,6 +57,17 @@ impl<'a> LineStringArrayParts<'a> {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn values_iter_coords(&self) -> impl Iterator<Item = Coord> + '_ {
+        self.x
+            .values_iter()
+            .zip(self.y.values_iter())
+            .map(|(x, y)| Coord { x: *x, y: *y })
+    }
+
+    pub fn iter_coords(&self) -> ZipValidity<Coord, impl Iterator<Item = Coord> + '_, BitmapIter> {
+        ZipValidity::new_with_validity(self.values_iter_coords(), self.validity)
     }
 
     pub fn get_as_geo(&self, i: usize) -> Option<LineString> {

--- a/geopolars/src/geoarrow/point/array.rs
+++ b/geopolars/src/geoarrow/point/array.rs
@@ -1,7 +1,7 @@
 use geo::{Coord, Point};
 use polars::export::arrow::array::{Array, PrimitiveArray, StructArray};
+use polars::export::arrow::bitmap::utils::{BitmapIter, ZipValidity};
 use polars::export::arrow::bitmap::Bitmap;
-use polars::export::arrow::bitmap::utils::{ZipValidity, BitmapIter};
 use polars::prelude::Series;
 
 use crate::util::index_to_chunked_index;

--- a/geopolars/src/geoarrow/polygon/array.rs
+++ b/geopolars/src/geoarrow/polygon/array.rs
@@ -1,5 +1,6 @@
 use geo::{Coord, LineString, Polygon};
 use polars::export::arrow::array::{Array, ListArray, PrimitiveArray, StructArray};
+use polars::export::arrow::bitmap::utils::{BitmapIter, ZipValidity};
 use polars::export::arrow::bitmap::Bitmap;
 use polars::export::arrow::offset::OffsetsBuffer;
 use polars::prelude::Series;
@@ -54,6 +55,17 @@ impl<'a> PolygonArrayParts<'a> {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn values_iter_coords(&self) -> impl Iterator<Item = Coord> + '_ {
+        self.x
+            .values_iter()
+            .zip(self.y.values_iter())
+            .map(|(x, y)| Coord { x: *x, y: *y })
+    }
+
+    pub fn iter_coords(&self) -> ZipValidity<Coord, impl Iterator<Item = Coord> + '_, BitmapIter> {
+        ZipValidity::new_with_validity(self.values_iter_coords(), self.validity)
     }
 
     pub fn get_as_geo(&self, i: usize) -> Option<Polygon> {

--- a/geopolars/src/ops/affine.rs
+++ b/geopolars/src/ops/affine.rs
@@ -1,10 +1,6 @@
 use crate::error::Result;
-use crate::geoarrow::linestring::array::LineStringSeries;
-use crate::geoarrow::linestring::mutable::MutableLineStringArray;
 use crate::geoarrow::point::array::PointSeries;
 use crate::geoarrow::point::mutable::MutablePointArray;
-use crate::geoarrow::polygon::array::PolygonSeries;
-use crate::geoarrow::polygon::mutable::MutablePolygonArray;
 use crate::util::{from_geom_vec, get_geoarrow_type, GeoArrowType};
 use geo::algorithm::affine_ops::AffineTransform;
 use geo::algorithm::bounding_rect::BoundingRect;


### PR DESCRIPTION
- Affine transform for geoarrow points
- helpers for iterating over coordinates

Benchmark:
```
translate               time:   [117.52 µs 118.78 µs 120.40 µs]

translate geoarrow      time:   [5.6917 µs 5.7521 µs 5.8163 µs]
```