### PR TITLE
geoarrow: refactor GeometryArrayTrait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "689894c2db1ea643a50834b999abf1c110887402542955ff5451dab8f861f9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -926,7 +926,6 @@ dependencies = [
  "anyhow",
  "arrow2",
  "criterion",
- "dyn-clone",
  "geo",
  "geos",
  "geozero",

--- a/geopolars/datasets
+++ b/geopolars/datasets
@@ -1,0 +1,1 @@
+../py-geopolars/python/geopolars/datasets/

--- a/geopolars/geopolars-arrow/Cargo.toml
+++ b/geopolars/geopolars-arrow/Cargo.toml
@@ -10,7 +10,6 @@ description = "Utilities for working with GeoArrow"
 [dependencies]
 geo.workspace = true
 geos = { version = "8", features = ["v3_8_0", "geo"], optional = true }
-dyn-clone = "1"
 thiserror.workspace = true
 anyhow = "1.0"
 geozero = { version = "0.9.4", features = ["with-wkb"] }

--- a/geopolars/geopolars-arrow/benches/rtree.rs
+++ b/geopolars/geopolars-arrow/benches/rtree.rs
@@ -2,7 +2,7 @@ use arrow2::array::BinaryArray;
 use arrow2::io::parquet::read::{infer_schema, read_metadata, FileReader};
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use geo::BoundingRect;
-use geopolars_arrow::MultiPolygonArray;
+use geopolars_arrow::{GeometryArrayTrait, MultiPolygonArray};
 use geozero::wkb::Wkb;
 use geozero::ToGeo;
 use rstar::{RTree, RTreeObject, AABB};
@@ -87,8 +87,6 @@ fn bench_rtree_from_geo(b: &mut Bencher) {
 }
 
 fn benchmark_group(c: &mut Criterion) {
-    better_panic::debug_install();
-
     c.bench_function("rtree_from_geoarrow", bench_rtree_from_geoarrow);
     c.bench_function("rtree_from_geo", bench_rtree_from_geo);
 }

--- a/geopolars/geopolars-arrow/src/binary/mutable.rs
+++ b/geopolars/geopolars-arrow/src/binary/mutable.rs
@@ -1,10 +1,8 @@
+use crate::trait_::MutableGeometryArray;
 use arrow2::array::{MutableArray, MutableBinaryArray};
 use arrow2::bitmap::MutableBitmap;
 use geo::Geometry;
 use geozero::{CoordDimensions, ToWkb};
-
-use crate::enum_::GeometryType;
-use crate::trait_::MutableGeometryArray;
 
 use super::array::WKBArray;
 
@@ -41,10 +39,6 @@ impl MutableWKBArray {
 }
 
 impl MutableGeometryArray for MutableWKBArray {
-    fn geometry_type(&self) -> GeometryType {
-        GeometryType::WKB
-    }
-
     fn len(&self) -> usize {
         self.0.values().len()
     }

--- a/geopolars/geopolars-arrow/src/enum_.rs
+++ b/geopolars/geopolars-arrow/src/enum_.rs
@@ -1,23 +1,55 @@
+use crate::GeometryArrayTrait;
 use arrow2::array::Array;
-use geo::Geometry;
+use arrow2::bitmap::Bitmap;
+use rstar::{RTree, RTreeObject, AABB};
 
 use crate::{
     LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray,
     PolygonArray, WKBArray,
 };
 
-#[derive(Clone, Debug)]
-pub enum GeometryType {
-    Point,
-    LineString,
-    Polygon,
-    MultiPoint,
-    MultiLineString,
-    MultiPolygon,
-    WKB,
+pub enum Geometry<'a> {
+    Point(crate::Point<'a>),
+    LineString(crate::LineString<'a>),
+    Polygon(crate::Polygon<'a>),
+    MultiPoint(crate::MultiPoint<'a>),
+    MultiLineString(crate::MultiLineString<'a>),
+    MultiPolygon(crate::MultiPolygon<'a>),
+    WKB(crate::WKB<'a>),
 }
 
-pub enum GeometryArrayEnum {
+impl RTreeObject for Geometry<'_> {
+    type Envelope = AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        match self {
+            Geometry::Point(geom) => geom.envelope(),
+            Geometry::LineString(geom) => geom.envelope(),
+            Geometry::Polygon(geom) => geom.envelope(),
+            Geometry::MultiPoint(geom) => geom.envelope(),
+            Geometry::MultiLineString(geom) => geom.envelope(),
+            Geometry::MultiPolygon(geom) => geom.envelope(),
+            Geometry::WKB(geom) => geom.envelope(),
+        }
+    }
+}
+
+impl From<Geometry<'_>> for geo::Geometry {
+    fn from(value: Geometry) -> Self {
+        match value {
+            Geometry::Point(geom) => geom.into(),
+            Geometry::LineString(geom) => geom.into(),
+            Geometry::Polygon(geom) => geom.into(),
+            Geometry::MultiPoint(geom) => geom.into(),
+            Geometry::MultiLineString(geom) => geom.into(),
+            Geometry::MultiPolygon(geom) => geom.into(),
+            Geometry::WKB(geom) => geom.into(),
+        }
+    }
+}
+
+/// An enum representing an immutable Arrow geometry array.
+pub enum GeometryArray {
     Point(PointArray),
     LineString(LineStringArray),
     Polygon(PolygonArray),
@@ -27,49 +59,138 @@ pub enum GeometryArrayEnum {
     WKB(WKBArray),
 }
 
-impl GeometryArrayEnum {
-    /// Returns the number of geometries in this array
-    pub fn len(&self) -> usize {
+impl<'a> GeometryArrayTrait<'a> for GeometryArray {
+    type Scalar = Geometry<'a>;
+    type ScalarGeo = geo::Geometry;
+    type ArrowArray = Box<dyn Array>;
+
+    fn value(&'a self, i: usize) -> Self::Scalar {
         match self {
-            GeometryArrayEnum::Point(arr) => arr.len(),
-            GeometryArrayEnum::LineString(arr) => arr.len(),
-            GeometryArrayEnum::Polygon(arr) => arr.len(),
-            GeometryArrayEnum::MultiPoint(arr) => arr.len(),
-            GeometryArrayEnum::MultiLineString(arr) => arr.len(),
-            GeometryArrayEnum::MultiPolygon(arr) => arr.len(),
-            GeometryArrayEnum::WKB(arr) => arr.len(),
+            GeometryArray::Point(arr) => Geometry::Point(arr.value(i)),
+            GeometryArray::LineString(arr) => Geometry::LineString(arr.value(i)),
+            GeometryArray::Polygon(arr) => Geometry::Polygon(arr.value(i)),
+            GeometryArray::MultiPoint(arr) => Geometry::MultiPoint(arr.value(i)),
+            GeometryArray::MultiLineString(arr) => Geometry::MultiLineString(arr.value(i)),
+            GeometryArray::MultiPolygon(arr) => Geometry::MultiPolygon(arr.value(i)),
+            GeometryArray::WKB(arr) => Geometry::WKB(arr.value(i)),
         }
     }
 
-    /// Returns true if the array is empty
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn into_arrow(self) -> Box<dyn Array> {
+    fn into_arrow(self) -> Self::ArrowArray {
         match self {
-            GeometryArrayEnum::Point(arr) => arr.into_arrow().boxed(),
-            GeometryArrayEnum::LineString(arr) => arr.into_arrow().boxed(),
-            GeometryArrayEnum::Polygon(arr) => arr.into_arrow().boxed(),
-            GeometryArrayEnum::MultiPoint(arr) => arr.into_arrow().boxed(),
-            GeometryArrayEnum::MultiLineString(arr) => arr.into_arrow().boxed(),
-            GeometryArrayEnum::MultiPolygon(arr) => arr.into_arrow().boxed(),
-            GeometryArrayEnum::WKB(arr) => arr.into_arrow().boxed(),
+            GeometryArray::Point(arr) => arr.into_arrow().boxed(),
+            GeometryArray::LineString(arr) => arr.into_arrow().boxed(),
+            GeometryArray::Polygon(arr) => arr.into_arrow().boxed(),
+            GeometryArray::MultiPoint(arr) => arr.into_arrow().boxed(),
+            GeometryArray::MultiLineString(arr) => arr.into_arrow().boxed(),
+            GeometryArray::MultiPolygon(arr) => arr.into_arrow().boxed(),
+            GeometryArray::WKB(arr) => arr.into_arrow().boxed(),
         }
     }
 
-    /// Get as geo Geometry object
-    pub fn get_as_geo(self, i: usize) -> Option<Geometry> {
+    fn rstar_tree(&'a self) -> rstar::RTree<Self::Scalar> {
+        let mut tree = RTree::new();
+        (0..self.len())
+            .into_iter()
+            .filter_map(|geom_idx| self.get(geom_idx))
+            .for_each(|geom| tree.insert(geom));
+        tree
+    }
+
+    /// The length of the [`GeometryArray`]. Every array has a length corresponding to the number
+    /// of geometries it contains.
+    fn len(&self) -> usize {
         match self {
-            GeometryArrayEnum::Point(arr) => arr.get_as_geo(i).map(Geometry::Point),
-            GeometryArrayEnum::LineString(arr) => arr.get_as_geo(i).map(Geometry::LineString),
-            GeometryArrayEnum::Polygon(arr) => arr.get_as_geo(i).map(Geometry::Polygon),
-            GeometryArrayEnum::MultiPoint(arr) => arr.get_as_geo(i).map(Geometry::MultiPoint),
-            GeometryArrayEnum::MultiLineString(arr) => {
-                arr.get_as_geo(i).map(Geometry::MultiLineString)
+            GeometryArray::Point(arr) => arr.len(),
+            GeometryArray::LineString(arr) => arr.len(),
+            GeometryArray::Polygon(arr) => arr.len(),
+            GeometryArray::MultiPoint(arr) => arr.len(),
+            GeometryArray::MultiLineString(arr) => arr.len(),
+            GeometryArray::MultiPolygon(arr) => arr.len(),
+            GeometryArray::WKB(arr) => arr.len(),
+        }
+    }
+
+    /// The validity of the [`GeometryArray`]: every array has an optional [`Bitmap`] that, when
+    /// available specifies whether the geometry at a given slot is valid or not (null). When the
+    /// validity is [`None`], all slots are valid.
+    fn validity(&self) -> Option<&Bitmap> {
+        match self {
+            GeometryArray::Point(arr) => arr.validity(),
+            GeometryArray::LineString(arr) => arr.validity(),
+            GeometryArray::Polygon(arr) => arr.validity(),
+            GeometryArray::MultiPoint(arr) => arr.validity(),
+            GeometryArray::MultiLineString(arr) => arr.validity(),
+            GeometryArray::MultiPolygon(arr) => arr.validity(),
+            GeometryArray::WKB(arr) => arr.validity(),
+        }
+    }
+
+    /// Slices the [`GeometryArray`], returning a new [`GeometryArray`].
+    /// # Implementation
+    /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
+    /// and moving the struct to the heap.
+    /// # Panic
+    /// This function panics iff `offset + length > self.len()`.
+    fn slice(&self, offset: usize, length: usize) -> GeometryArray {
+        match self {
+            GeometryArray::Point(arr) => GeometryArray::Point(arr.slice(offset, length)),
+            GeometryArray::LineString(arr) => GeometryArray::LineString(arr.slice(offset, length)),
+            GeometryArray::Polygon(arr) => GeometryArray::Polygon(arr.slice(offset, length)),
+            GeometryArray::MultiPoint(arr) => GeometryArray::MultiPoint(arr.slice(offset, length)),
+            GeometryArray::MultiLineString(arr) => {
+                GeometryArray::MultiLineString(arr.slice(offset, length))
             }
-            GeometryArrayEnum::MultiPolygon(arr) => arr.get_as_geo(i).map(Geometry::MultiPolygon),
-            GeometryArrayEnum::WKB(arr) => arr.get_as_geo(i),
+            GeometryArray::MultiPolygon(arr) => {
+                GeometryArray::MultiPolygon(arr.slice(offset, length))
+            }
+            GeometryArray::WKB(arr) => GeometryArray::WKB(arr.slice(offset, length)),
         }
+    }
+
+    /// Slices the [`GeometryArray`], returning a new [`GeometryArray`].
+    /// # Implementation
+    /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
+    /// and moving the struct to the heap.
+    /// # Safety
+    /// The caller must ensure that `offset + length <= self.len()`
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> GeometryArray {
+        match self {
+            GeometryArray::Point(arr) => GeometryArray::Point(arr.slice_unchecked(offset, length)),
+            GeometryArray::LineString(arr) => {
+                GeometryArray::LineString(arr.slice_unchecked(offset, length))
+            }
+            GeometryArray::Polygon(arr) => {
+                GeometryArray::Polygon(arr.slice_unchecked(offset, length))
+            }
+            GeometryArray::MultiPoint(arr) => {
+                GeometryArray::MultiPoint(arr.slice_unchecked(offset, length))
+            }
+            GeometryArray::MultiLineString(arr) => {
+                GeometryArray::MultiLineString(arr.slice_unchecked(offset, length))
+            }
+            GeometryArray::MultiPolygon(arr) => {
+                GeometryArray::MultiPolygon(arr.slice_unchecked(offset, length))
+            }
+            GeometryArray::WKB(arr) => GeometryArray::WKB(arr.slice_unchecked(offset, length)),
+        }
+    }
+
+    // /// Clones this [`GeometryArray`] with a new assigned bitmap.
+    // /// # Panic
+    // /// This function panics iff `validity.len() != self.len()`.
+    // pub fn with_validity(&self, validity: Option<Bitmap>) -> Box<GeometryArrayTrait>;
+
+    /// Clone a [`GeometryArray`] to an owned `Box<GeometryArray>`.
+    fn to_boxed(&self) -> Box<GeometryArray> {
+        Box::new(match self {
+            GeometryArray::Point(arr) => GeometryArray::Point(arr.clone()),
+            GeometryArray::LineString(arr) => GeometryArray::LineString(arr.clone()),
+            GeometryArray::Polygon(arr) => GeometryArray::Polygon(arr.clone()),
+            GeometryArray::MultiPoint(arr) => GeometryArray::MultiPoint(arr.clone()),
+            GeometryArray::MultiLineString(arr) => GeometryArray::MultiLineString(arr.clone()),
+            GeometryArray::MultiPolygon(arr) => GeometryArray::MultiPolygon(arr.clone()),
+            GeometryArray::WKB(arr) => GeometryArray::WKB(arr.clone()),
+        })
     }
 }

--- a/geopolars/geopolars-arrow/src/geo_traits/point.rs
+++ b/geopolars/geopolars-arrow/src/geo_traits/point.rs
@@ -56,6 +56,7 @@ impl PointTrait for &Coord<f64> {
 #[cfg(test)]
 mod tests {
     use super::PointTrait;
+    use crate::GeometryArrayTrait;
     use crate::PointArray;
 
     #[test]

--- a/geopolars/geopolars-arrow/src/lib.rs
+++ b/geopolars/geopolars-arrow/src/lib.rs
@@ -4,14 +4,14 @@
 //! integrated into geozero
 
 pub use binary::{MutableWKBArray, WKBArray, WKB};
-pub use enum_::{GeometryArrayEnum, GeometryType};
+pub use enum_::GeometryArray;
 pub use linestring::{LineString, LineStringArray, MutableLineStringArray};
 pub use multilinestring::{MultiLineString, MultiLineStringArray, MutableMultiLineStringArray};
 pub use multipoint::{MultiPoint, MultiPointArray, MutableMultiPointArray};
 pub use multipolygon::{MultiPolygon, MultiPolygonArray, MutableMultiPolygonArray};
 pub use point::{MutablePointArray, Point, PointArray};
 pub use polygon::{MutablePolygonArray, Polygon, PolygonArray};
-pub use trait_::GeometryArray;
+pub use trait_::GeometryArrayTrait;
 
 pub mod algorithm;
 pub mod binary;

--- a/geopolars/geopolars-arrow/src/linestring/array.rs
+++ b/geopolars/geopolars-arrow/src/linestring/array.rs
@@ -1,7 +1,5 @@
-use crate::enum_::GeometryType;
 use crate::error::GeoArrowError;
-use crate::trait_::GeometryArray;
-use crate::MultiPointArray;
+use crate::{GeometryArrayTrait, MultiPointArray};
 use arrow2::array::{Array, ListArray, PrimitiveArray, StructArray};
 use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
 use arrow2::bitmap::Bitmap;
@@ -87,21 +85,66 @@ impl LineStringArray {
             validity,
         })
     }
+}
+
+impl<'a> GeometryArrayTrait<'a> for LineStringArray {
+    type Scalar = crate::LineString<'a>;
+    type ScalarGeo = geo::LineString;
+    type ArrowArray = ListArray<i64>;
+
+    /// Gets the value at slot `i`
+    fn value(&'a self, i: usize) -> Self::Scalar {
+        crate::LineString {
+            x: &self.x,
+            y: &self.y,
+            geom_offsets: &self.geom_offsets,
+            geom_index: i,
+        }
+    }
+
+    fn into_arrow(self) -> ListArray<i64> {
+        // Data type
+        let coord_field_x = Field::new("x", DataType::Float64, false);
+        let coord_field_y = Field::new("y", DataType::Float64, false);
+        let struct_data_type = DataType::Struct(vec![coord_field_x, coord_field_y]);
+        let list_data_type = DataType::LargeList(Box::new(Field::new(
+            "vertices",
+            struct_data_type.clone(),
+            true,
+        )));
+
+        // Validity
+        let validity: Option<Bitmap> = if let Some(validity) = self.validity {
+            validity.into()
+        } else {
+            None
+        };
+
+        // Array data
+        let array_x = PrimitiveArray::new(DataType::Float64, self.x, None).boxed();
+        let array_y = PrimitiveArray::new(DataType::Float64, self.y, None).boxed();
+
+        let coord_array = StructArray::new(struct_data_type, vec![array_x, array_y], None).boxed();
+
+        ListArray::new(list_data_type, self.geom_offsets, coord_array, validity)
+    }
+
+    /// Build a spatial index containing this array's geometries
+    fn rstar_tree(&'a self) -> RTree<Self::Scalar> {
+        let mut tree = RTree::new();
+        self.iter().flatten().for_each(|geom| tree.insert(geom));
+        tree
+    }
 
     /// Returns the number of geometries in this array
     #[inline]
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.geom_offsets.len()
-    }
-
-    /// Returns true if the array is empty
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
     }
 
     /// Returns the optional validity.
     #[inline]
-    pub fn validity(&self) -> Option<&Bitmap> {
+    fn validity(&self) -> Option<&Bitmap> {
         self.validity.as_ref()
     }
 
@@ -122,7 +165,7 @@ impl LineStringArray {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     #[must_use]
-    pub fn slice(&self, offset: usize, length: usize) -> Self {
+    fn slice(&self, offset: usize, length: usize) -> Self {
         assert!(
             offset + length <= self.len(),
             "offset + length may not exceed length of array"
@@ -137,7 +180,7 @@ impl LineStringArray {
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
     #[must_use]
-    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self
             .validity
             .clone()
@@ -156,29 +199,14 @@ impl LineStringArray {
             validity,
         }
     }
+
+    fn to_boxed(&self) -> Box<Self> {
+        Box::new(self.clone())
+    }
 }
 
 // Implement geometry accessors
 impl LineStringArray {
-    /// Gets the value at slot `i`
-    pub fn value(&self, i: usize) -> crate::LineString {
-        crate::LineString {
-            x: &self.x,
-            y: &self.y,
-            geom_offsets: &self.geom_offsets,
-            geom_index: i,
-        }
-    }
-
-    /// Gets the item at slot `i`, additionally checking the validity bitmap
-    pub fn get(&self, i: usize) -> Option<crate::LineString> {
-        if self.is_null(i) {
-            return None;
-        }
-
-        Some(self.value(i))
-    }
-
     pub fn iter_values(&self) -> impl Iterator<Item = crate::LineString> + '_ {
         (0..self.len()).map(|i| self.value(i))
     }
@@ -245,40 +273,6 @@ impl LineStringArray {
     ) -> ZipValidity<geos::Geometry, impl Iterator<Item = geos::Geometry> + '_, BitmapIter> {
         ZipValidity::new_with_validity(self.iter_geos_values(), self.validity())
     }
-
-    pub fn into_arrow(self) -> ListArray<i64> {
-        // Data type
-        let coord_field_x = Field::new("x", DataType::Float64, false);
-        let coord_field_y = Field::new("y", DataType::Float64, false);
-        let struct_data_type = DataType::Struct(vec![coord_field_x, coord_field_y]);
-        let list_data_type = DataType::LargeList(Box::new(Field::new(
-            "vertices",
-            struct_data_type.clone(),
-            true,
-        )));
-
-        // Validity
-        let validity: Option<Bitmap> = if let Some(validity) = self.validity {
-            validity.into()
-        } else {
-            None
-        };
-
-        // Array data
-        let array_x = PrimitiveArray::new(DataType::Float64, self.x, None).boxed();
-        let array_y = PrimitiveArray::new(DataType::Float64, self.y, None).boxed();
-
-        let coord_array = StructArray::new(struct_data_type, vec![array_x, array_y], None).boxed();
-
-        ListArray::new(list_data_type, self.geom_offsets, coord_array, validity)
-    }
-
-    /// Build a spatial index containing this array's geometries
-    pub fn rstar_tree(&self) -> RTree<crate::LineString> {
-        let mut tree = RTree::new();
-        self.iter().flatten().for_each(|geom| tree.insert(geom));
-        tree
-    }
 }
 
 impl TryFrom<ListArray<i64>> for LineStringArray {
@@ -317,44 +311,6 @@ impl TryFrom<Box<dyn Array>> for LineStringArray {
     fn try_from(value: Box<dyn Array>) -> Result<Self, Self::Error> {
         let arr = value.as_any().downcast_ref::<ListArray<i64>>().unwrap();
         arr.clone().try_into()
-    }
-}
-
-impl GeometryArray for LineStringArray {
-    #[inline]
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    #[inline]
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
-    #[inline]
-    fn len(&self) -> usize {
-        self.len()
-    }
-
-    #[inline]
-    fn geometry_type(&self) -> GeometryType {
-        GeometryType::WKB
-    }
-
-    fn validity(&self) -> Option<&Bitmap> {
-        self.validity()
-    }
-
-    fn slice(&self, offset: usize, length: usize) -> Box<dyn GeometryArray> {
-        Box::new(self.slice(offset, length))
-    }
-
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn GeometryArray> {
-        Box::new(self.slice_unchecked(offset, length))
-    }
-
-    fn to_boxed(&self) -> Box<dyn GeometryArray> {
-        Box::new(self.clone())
     }
 }
 

--- a/geopolars/geopolars-arrow/src/linestring/mutable.rs
+++ b/geopolars/geopolars-arrow/src/linestring/mutable.rs
@@ -1,5 +1,6 @@
 use crate::error::GeoArrowError;
 use crate::multipoint::MutableMultiPointArray;
+use crate::GeometryArrayTrait;
 use crate::LineStringArray;
 use arrow2::array::ListArray;
 use arrow2::bitmap::{Bitmap, MutableBitmap};

--- a/geopolars/geopolars-arrow/src/linestring/scalar.rs
+++ b/geopolars/geopolars-arrow/src/linestring/scalar.rs
@@ -71,6 +71,12 @@ impl From<&LineString<'_>> for geo::LineString {
     }
 }
 
+impl From<LineString<'_>> for geo::Geometry {
+    fn from(value: LineString<'_>) -> Self {
+        geo::Geometry::LineString(value.into())
+    }
+}
+
 impl RTreeObject for LineString<'_> {
     type Envelope = AABB<[f64; 2]>;
 

--- a/geopolars/geopolars-arrow/src/multilinestring/mutable.rs
+++ b/geopolars/geopolars-arrow/src/multilinestring/mutable.rs
@@ -1,3 +1,4 @@
+use crate::GeometryArrayTrait;
 use arrow2::array::ListArray;
 use arrow2::bitmap::{Bitmap, MutableBitmap};
 use arrow2::offset::{Offsets, OffsetsBuffer};

--- a/geopolars/geopolars-arrow/src/multilinestring/scalar.rs
+++ b/geopolars/geopolars-arrow/src/multilinestring/scalar.rs
@@ -76,6 +76,12 @@ impl From<&MultiLineString<'_>> for geo::MultiLineString {
     }
 }
 
+impl From<MultiLineString<'_>> for geo::Geometry {
+    fn from(value: MultiLineString<'_>) -> Self {
+        geo::Geometry::MultiLineString(value.into())
+    }
+}
+
 impl RTreeObject for MultiLineString<'_> {
     type Envelope = AABB<[f64; 2]>;
 

--- a/geopolars/geopolars-arrow/src/multipoint/mutable.rs
+++ b/geopolars/geopolars-arrow/src/multipoint/mutable.rs
@@ -1,8 +1,7 @@
 use super::array::MultiPointArray;
-use crate::enum_::GeometryType;
 use crate::error::GeoArrowError;
 use crate::linestring::MutableLineStringArray;
-use crate::trait_::MutableGeometryArray;
+use crate::trait_::{GeometryArrayTrait, MutableGeometryArray};
 use arrow2::array::ListArray;
 use arrow2::bitmap::{Bitmap, MutableBitmap};
 use arrow2::offset::Offsets;
@@ -124,10 +123,6 @@ impl Default for MutableMultiPointArray {
 }
 
 impl MutableGeometryArray for MutableMultiPointArray {
-    fn geometry_type(&self) -> GeometryType {
-        GeometryType::Point
-    }
-
     fn len(&self) -> usize {
         self.x.len()
     }

--- a/geopolars/geopolars-arrow/src/multipoint/scalar.rs
+++ b/geopolars/geopolars-arrow/src/multipoint/scalar.rs
@@ -70,6 +70,12 @@ impl From<&MultiPoint<'_>> for geo::MultiPoint {
     }
 }
 
+impl From<MultiPoint<'_>> for geo::Geometry {
+    fn from(value: MultiPoint<'_>) -> Self {
+        geo::Geometry::MultiPoint(value.into())
+    }
+}
+
 impl RTreeObject for MultiPoint<'_> {
     type Envelope = AABB<[f64; 2]>;
 

--- a/geopolars/geopolars-arrow/src/multipolygon/mutable.rs
+++ b/geopolars/geopolars-arrow/src/multipolygon/mutable.rs
@@ -1,3 +1,4 @@
+use crate::GeometryArrayTrait;
 use arrow2::array::ListArray;
 use arrow2::bitmap::{Bitmap, MutableBitmap};
 use arrow2::offset::{Offsets, OffsetsBuffer};

--- a/geopolars/geopolars-arrow/src/multipolygon/scalar.rs
+++ b/geopolars/geopolars-arrow/src/multipolygon/scalar.rs
@@ -79,6 +79,12 @@ impl From<&MultiPolygon<'_>> for geo::MultiPolygon {
     }
 }
 
+impl From<MultiPolygon<'_>> for geo::Geometry {
+    fn from(value: MultiPolygon<'_>) -> Self {
+        geo::Geometry::MultiPolygon(value.into())
+    }
+}
+
 impl RTreeObject for MultiPolygon<'_> {
     type Envelope = AABB<[f64; 2]>;
 

--- a/geopolars/geopolars-arrow/src/point/mutable.rs
+++ b/geopolars/geopolars-arrow/src/point/mutable.rs
@@ -1,6 +1,5 @@
-use crate::enum_::GeometryType;
 use crate::error::GeoArrowError;
-use crate::trait_::MutableGeometryArray;
+use crate::trait_::{GeometryArrayTrait, MutableGeometryArray};
 use arrow2::array::StructArray;
 use arrow2::bitmap::{Bitmap, MutableBitmap};
 use geo::Point;
@@ -111,10 +110,6 @@ impl MutablePointArray {
 }
 
 impl MutableGeometryArray for MutablePointArray {
-    fn geometry_type(&self) -> GeometryType {
-        GeometryType::Point
-    }
-
     fn len(&self) -> usize {
         self.x.len()
     }

--- a/geopolars/geopolars-arrow/src/point/scalar.rs
+++ b/geopolars/geopolars-arrow/src/point/scalar.rs
@@ -51,6 +51,12 @@ impl From<&Point<'_>> for geo::Point {
     }
 }
 
+impl From<Point<'_>> for geo::Geometry {
+    fn from(value: Point<'_>) -> Self {
+        geo::Geometry::Point(value.into())
+    }
+}
+
 impl RTreeObject for Point<'_> {
     type Envelope = AABB<[f64; 2]>;
 

--- a/geopolars/geopolars-arrow/src/polygon/array.rs
+++ b/geopolars/geopolars-arrow/src/polygon/array.rs
@@ -1,7 +1,5 @@
-use crate::enum_::GeometryType;
 use crate::error::GeoArrowError;
-use crate::trait_::GeometryArray;
-use crate::MultiLineStringArray;
+use crate::{GeometryArrayTrait, MultiLineStringArray};
 use arrow2::array::Array;
 use arrow2::array::{ListArray, PrimitiveArray, StructArray};
 use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
@@ -14,7 +12,7 @@ use rstar::RTree;
 
 use super::MutablePolygonArray;
 
-/// A [`GeometryArray`] semantically equivalent to `Vec<Option<Polygon>>` using Arrow's
+/// A [`GeometryArrayTrait`] semantically equivalent to `Vec<Option<Polygon>>` using Arrow's
 /// in-memory representation.
 #[derive(Debug, Clone)]
 pub struct PolygonArray {
@@ -95,21 +93,79 @@ impl PolygonArray {
             validity,
         })
     }
+}
+
+impl<'a> GeometryArrayTrait<'a> for PolygonArray {
+    type Scalar = crate::Polygon<'a>;
+    type ScalarGeo = geo::Polygon;
+    type ArrowArray = ListArray<i64>;
+
+    fn value(&'a self, i: usize) -> Self::Scalar {
+        crate::Polygon {
+            x: &self.x,
+            y: &self.y,
+            geom_offsets: &self.geom_offsets,
+            ring_offsets: &self.ring_offsets,
+            geom_index: i,
+        }
+    }
+
+    fn into_arrow(self) -> Self::ArrowArray {
+        // Data type
+        let coord_field_x = Field::new("x", DataType::Float64, false);
+        let coord_field_y = Field::new("y", DataType::Float64, false);
+        let struct_data_type = DataType::Struct(vec![coord_field_x, coord_field_y]);
+        let inner_list_data_type = DataType::LargeList(Box::new(Field::new(
+            "vertices",
+            struct_data_type.clone(),
+            false,
+        )));
+        let outer_list_data_type = DataType::LargeList(Box::new(Field::new(
+            "rings",
+            inner_list_data_type.clone(),
+            true,
+        )));
+
+        // Validity
+        let validity: Option<Bitmap> = if let Some(validity) = self.validity {
+            validity.into()
+        } else {
+            None
+        };
+
+        // Array data
+        let array_x = PrimitiveArray::new(DataType::Float64, self.x, None).boxed();
+        let array_y = PrimitiveArray::new(DataType::Float64, self.y, None).boxed();
+
+        let coord_array = StructArray::new(struct_data_type, vec![array_x, array_y], None).boxed();
+
+        let inner_list_array =
+            ListArray::new(inner_list_data_type, self.ring_offsets, coord_array, None).boxed();
+
+        ListArray::new(
+            outer_list_data_type,
+            self.geom_offsets,
+            inner_list_array,
+            validity,
+        )
+    }
+
+    /// Build a spatial index containing this array's geometries
+    fn rstar_tree(&'a self) -> RTree<Self::Scalar> {
+        let mut tree = RTree::new();
+        self.iter().flatten().for_each(|geom| tree.insert(geom));
+        tree
+    }
 
     /// Returns the number of geometries in this array
     #[inline]
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.geom_offsets.len()
-    }
-
-    /// Returns true if the array is empty
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
     }
 
     /// Returns the optional validity.
     #[inline]
-    pub fn validity(&self) -> Option<&Bitmap> {
+    fn validity(&self) -> Option<&Bitmap> {
         self.validity.as_ref()
     }
 
@@ -130,7 +186,7 @@ impl PolygonArray {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     #[must_use]
-    pub fn slice(&self, offset: usize, length: usize) -> Self {
+    fn slice(&self, offset: usize, length: usize) -> Self {
         assert!(
             offset + length <= self.len(),
             "offset + length may not exceed length of array"
@@ -145,7 +201,7 @@ impl PolygonArray {
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
     #[must_use]
-    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self
             .validity
             .clone()
@@ -165,28 +221,14 @@ impl PolygonArray {
             validity,
         }
     }
+
+    fn to_boxed(&self) -> Box<Self> {
+        Box::new(self.clone())
+    }
 }
 
 // Implement geometry accessors
 impl PolygonArray {
-    pub fn value(&self, i: usize) -> crate::Polygon {
-        crate::Polygon {
-            x: &self.x,
-            y: &self.y,
-            geom_offsets: &self.geom_offsets,
-            ring_offsets: &self.ring_offsets,
-            geom_index: i,
-        }
-    }
-
-    pub fn get(&self, i: usize) -> Option<crate::Polygon> {
-        if self.is_null(i) {
-            return None;
-        }
-
-        Some(self.value(i))
-    }
-
     pub fn iter_values(&self) -> impl Iterator<Item = crate::Polygon> + '_ {
         (0..self.len()).map(|i| self.value(i))
     }
@@ -252,53 +294,6 @@ impl PolygonArray {
     ) -> ZipValidity<geos::Geometry, impl Iterator<Item = geos::Geometry> + '_, BitmapIter> {
         ZipValidity::new_with_validity(self.iter_geos_values(), self.validity())
     }
-
-    pub fn into_arrow(self) -> ListArray<i64> {
-        // Data type
-        let coord_field_x = Field::new("x", DataType::Float64, false);
-        let coord_field_y = Field::new("y", DataType::Float64, false);
-        let struct_data_type = DataType::Struct(vec![coord_field_x, coord_field_y]);
-        let inner_list_data_type = DataType::LargeList(Box::new(Field::new(
-            "vertices",
-            struct_data_type.clone(),
-            false,
-        )));
-        let outer_list_data_type = DataType::LargeList(Box::new(Field::new(
-            "rings",
-            inner_list_data_type.clone(),
-            true,
-        )));
-
-        // Validity
-        let validity: Option<Bitmap> = if let Some(validity) = self.validity {
-            validity.into()
-        } else {
-            None
-        };
-
-        // Array data
-        let array_x = PrimitiveArray::new(DataType::Float64, self.x, None).boxed();
-        let array_y = PrimitiveArray::new(DataType::Float64, self.y, None).boxed();
-
-        let coord_array = StructArray::new(struct_data_type, vec![array_x, array_y], None).boxed();
-
-        let inner_list_array =
-            ListArray::new(inner_list_data_type, self.ring_offsets, coord_array, None).boxed();
-
-        ListArray::new(
-            outer_list_data_type,
-            self.geom_offsets,
-            inner_list_array,
-            validity,
-        )
-    }
-
-    /// Build a spatial index containing this array's geometries
-    pub fn rstar_tree(&self) -> RTree<crate::Polygon> {
-        let mut tree = RTree::new();
-        self.iter().flatten().for_each(|geom| tree.insert(geom));
-        tree
-    }
 }
 
 impl TryFrom<ListArray<i64>> for PolygonArray {
@@ -346,44 +341,6 @@ impl TryFrom<Box<dyn Array>> for PolygonArray {
     fn try_from(value: Box<dyn Array>) -> Result<Self, Self::Error> {
         let arr = value.as_any().downcast_ref::<ListArray<i64>>().unwrap();
         arr.clone().try_into()
-    }
-}
-
-impl GeometryArray for PolygonArray {
-    #[inline]
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    #[inline]
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
-    #[inline]
-    fn len(&self) -> usize {
-        self.len()
-    }
-
-    #[inline]
-    fn geometry_type(&self) -> GeometryType {
-        GeometryType::WKB
-    }
-
-    fn validity(&self) -> Option<&Bitmap> {
-        self.validity()
-    }
-
-    fn slice(&self, offset: usize, length: usize) -> Box<dyn GeometryArray> {
-        Box::new(self.slice(offset, length))
-    }
-
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn GeometryArray> {
-        Box::new(self.slice_unchecked(offset, length))
-    }
-
-    fn to_boxed(&self) -> Box<dyn GeometryArray> {
-        Box::new(self.clone())
     }
 }
 

--- a/geopolars/geopolars-arrow/src/polygon/mutable.rs
+++ b/geopolars/geopolars-arrow/src/polygon/mutable.rs
@@ -1,3 +1,4 @@
+use crate::trait_::GeometryArrayTrait;
 use arrow2::array::ListArray;
 use arrow2::bitmap::{Bitmap, MutableBitmap};
 use arrow2::offset::{Offsets, OffsetsBuffer};

--- a/geopolars/geopolars-arrow/src/polygon/scalar.rs
+++ b/geopolars/geopolars-arrow/src/polygon/scalar.rs
@@ -74,6 +74,12 @@ impl From<&Polygon<'_>> for geo::Polygon {
     }
 }
 
+impl From<Polygon<'_>> for geo::Geometry {
+    fn from(value: Polygon<'_>) -> Self {
+        geo::Geometry::Polygon(value.into())
+    }
+}
+
 impl RTreeObject for Polygon<'_> {
     type Envelope = AABB<[f64; 2]>;
 

--- a/geopolars/geopolars-arrow/src/trait_.rs
+++ b/geopolars/geopolars-arrow/src/trait_.rs
@@ -1,15 +1,39 @@
-use crate::enum_::GeometryType;
 use arrow2::bitmap::{Bitmap, MutableBitmap};
+use rstar::{RTree, RTreeObject};
 use std::any::Any;
 
-/// A trait representing an immutable Arrow geometry array. Arrow arrays are trait objects
-/// that are infallibly downcasted to concrete types according to the [`GeometryArray::data_type`].
-pub trait GeometryArray: Send + Sync + dyn_clone::DynClone + 'static {
-    /// Converts itself to a reference of [`Any`], which enables downcasting to concrete types.
-    fn as_any(&self) -> &dyn Any;
+pub trait GeometryArrayTrait<'a> {
+    type Scalar: RTreeObject;
+    type ScalarGeo: From<Self::Scalar>;
+    type ArrowArray;
 
-    /// Converts itself to a mutable reference of [`Any`], which enables mutable downcasting to concrete types.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn value(&'a self, i: usize) -> Self::Scalar;
+
+    fn get(&'a self, i: usize) -> Option<Self::Scalar> {
+        if self.is_null(i) {
+            return None;
+        }
+
+        Some(self.value(i))
+    }
+
+    fn value_as_geo(&'a self, i: usize) -> Self::ScalarGeo {
+        self.value(i).into()
+    }
+
+    /// Gets the value at slot `i` as a geo object, additionally checking the validity bitmap
+    fn get_as_geo(&'a self, i: usize) -> Option<Self::ScalarGeo> {
+        if self.is_null(i) {
+            return None;
+        }
+
+        Some(self.value_as_geo(i))
+    }
+
+    fn into_arrow(self) -> Self::ArrowArray;
+
+    /// Build a spatial index containing this array's geometries
+    fn rstar_tree(&'a self) -> RTree<Self::Scalar>;
 
     /// The length of the [`GeometryArray`]. Every array has a length corresponding to the number of
     /// elements (slots).
@@ -19,11 +43,6 @@ pub trait GeometryArray: Send + Sync + dyn_clone::DynClone + 'static {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
-
-    /// The [`GeometryType`] of the [`GeometryArray`]. In combination with
-    /// [`GeometryArray::as_any`], this can be used to downcast trait objects (`dyn GeometryArray`)
-    /// to concrete arrays.
-    fn geometry_type(&self) -> GeometryType;
 
     /// The validity of the [`GeometryArray`]: every array has an optional [`Bitmap`] that, when available
     /// specifies whether the array slot is valid or not (null).
@@ -66,7 +85,7 @@ pub trait GeometryArray: Send + Sync + dyn_clone::DynClone + 'static {
     /// and moving the struct to the heap.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
-    fn slice(&self, offset: usize, length: usize) -> Box<dyn GeometryArray>;
+    fn slice(&self, offset: usize, length: usize) -> Self;
 
     /// Slices the [`GeometryArray`], returning a new `Box<dyn GeometryArray>`.
     /// # Implementation
@@ -74,7 +93,7 @@ pub trait GeometryArray: Send + Sync + dyn_clone::DynClone + 'static {
     /// and moving the struct to the heap.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn GeometryArray>;
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self;
 
     // /// Clones this [`GeometryArray`] with a new new assigned bitmap.
     // /// # Panic
@@ -82,19 +101,16 @@ pub trait GeometryArray: Send + Sync + dyn_clone::DynClone + 'static {
     // fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn GeometryArray>;
 
     /// Clone a `&dyn GeometryArray` to an owned `Box<dyn GeometryArray>`.
-    fn to_boxed(&self) -> Box<dyn GeometryArray>;
+    fn to_boxed(&self) -> Box<Self>;
 }
 
-dyn_clone::clone_trait_object!(GeometryArray);
+// dyn_clone::clone_trait_object!(GeometryArray);
 
 /// A trait describing a mutable geometry array; i.e. an array whose values can be changed.
 /// Mutable arrays cannot be cloned but can be mutated in place,
 /// thereby making them useful to perform numeric operations without allocations.
 /// As in [`GeometryArray`], concrete arrays (such as [`MutablePointArray`]) implement how they are mutated.
 pub trait MutableGeometryArray: std::fmt::Debug + Send + Sync {
-    /// The [`GeometryType`] of the array.
-    fn geometry_type(&self) -> GeometryType;
-
     /// The length of the array.
     fn len(&self) -> usize;
 
@@ -107,13 +123,13 @@ pub trait MutableGeometryArray: std::fmt::Debug + Send + Sync {
     fn validity(&self) -> Option<&MutableBitmap>;
 
     // /// Convert itself to an (immutable) [`GeometryArray`].
-    // fn as_box(&mut self) -> Box<dyn GeometryArray>;
+    // fn as_box(&mut self) -> Box<GeometryArrayTrait>;
 
     // /// Convert itself to an (immutable) atomically reference counted [`GeometryArray`].
     // // This provided implementation has an extra allocation as it first
     // // boxes `self`, then converts the box into an `Arc`. Implementors may wish
     // // to avoid an allocation by skipping the box completely.
-    // fn as_arc(&mut self) -> std::sync::Arc<dyn GeometryArray> {
+    // fn as_arc(&mut self) -> std::sync::Arc<GeometryArrayTrait> {
     //     self.as_box().into()
     // }
 

--- a/geopolars/geopolars-arrow/src/trait_.rs
+++ b/geopolars/geopolars-arrow/src/trait_.rs
@@ -104,8 +104,6 @@ pub trait GeometryArrayTrait<'a> {
     fn to_boxed(&self) -> Box<Self>;
 }
 
-// dyn_clone::clone_trait_object!(GeometryArray);
-
 /// A trait describing a mutable geometry array; i.e. an array whose values can be changed.
 /// Mutable arrays cannot be cloned but can be mutated in place,
 /// thereby making them useful to perform numeric operations without allocations.

--- a/geopolars/geopolars-arrow/src/util.rs
+++ b/geopolars/geopolars-arrow/src/util.rs
@@ -1,39 +1,39 @@
-use crate::GeometryArrayEnum;
+use crate::GeometryArray;
 use arrow2::array::{Array, BinaryArray, ListArray, StructArray};
 use arrow2::datatypes::DataType;
 
-pub fn array_to_geometry_array(arr: &dyn Array, is_multi: bool) -> GeometryArrayEnum {
+pub fn array_to_geometry_array(arr: &dyn Array, is_multi: bool) -> GeometryArray {
     match arr.data_type() {
         DataType::LargeBinary => {
             let lit_arr = arr.as_any().downcast_ref::<BinaryArray<i64>>().unwrap();
-            GeometryArrayEnum::WKB(lit_arr.clone().into())
+            GeometryArray::WKB(lit_arr.clone().into())
         }
         DataType::Struct(_) => {
             let lit_arr = arr.as_any().downcast_ref::<StructArray>().unwrap();
-            GeometryArrayEnum::Point(lit_arr.clone().try_into().unwrap())
+            GeometryArray::Point(lit_arr.clone().try_into().unwrap())
         }
         DataType::List(dt) | DataType::LargeList(dt) => match dt.data_type() {
             DataType::Struct(_) => {
                 let lit_arr = arr.as_any().downcast_ref::<ListArray<i64>>().unwrap();
 
                 if is_multi {
-                    GeometryArrayEnum::MultiPoint(lit_arr.clone().try_into().unwrap())
+                    GeometryArray::MultiPoint(lit_arr.clone().try_into().unwrap())
                 } else {
-                    GeometryArrayEnum::LineString(lit_arr.clone().try_into().unwrap())
+                    GeometryArray::LineString(lit_arr.clone().try_into().unwrap())
                 }
             }
             DataType::List(dt2) | DataType::LargeList(dt2) => match dt2.data_type() {
                 DataType::Struct(_) => {
                     let lit_arr = arr.as_any().downcast_ref::<ListArray<i64>>().unwrap();
                     if is_multi {
-                        GeometryArrayEnum::MultiLineString(lit_arr.clone().try_into().unwrap())
+                        GeometryArray::MultiLineString(lit_arr.clone().try_into().unwrap())
                     } else {
-                        GeometryArrayEnum::Polygon(lit_arr.clone().try_into().unwrap())
+                        GeometryArray::Polygon(lit_arr.clone().try_into().unwrap())
                     }
                 }
                 DataType::List(_) | DataType::LargeList(_) => {
                     let lit_arr = arr.as_any().downcast_ref::<ListArray<i64>>().unwrap();
-                    GeometryArrayEnum::MultiPolygon(lit_arr.clone().try_into().unwrap())
+                    GeometryArray::MultiPolygon(lit_arr.clone().try_into().unwrap())
                 }
                 _ => panic!("Unexpected inner list type: {:?}", dt2),
             },

--- a/geopolars/geopolars-geo/src/geoseries.rs
+++ b/geopolars/geopolars-geo/src/geoseries.rs
@@ -6,6 +6,7 @@ use crate::ops::proj::ProjOptions;
 use crate::util::{series_from_any_chunks, struct_series_from_chunks};
 use geo::algorithm::affine_ops::AffineTransform;
 use geopolars_arrow::util::array_to_geometry_array;
+use geopolars_arrow::GeometryArrayTrait;
 use polars::export::arrow::array::Array;
 use polars::prelude::{BooleanChunked, Float64Chunked, ListChunked, Series};
 use polars::series::IntoSeries;

--- a/geopolars/geopolars-geo/src/ops/affine.rs
+++ b/geopolars/geopolars-geo/src/ops/affine.rs
@@ -6,7 +6,7 @@
 // use geo::map_coords::MapCoords;
 use geo::Point;
 // use geo::{Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
-// use geopolars_arrow::GeometryArrayEnum;
+// use geopolars_arrow::GeometryArray;
 // use polars::prelude::Series;
 
 // use crate::util::iter_geom;
@@ -27,73 +27,73 @@ pub enum TransformOrigin {
 }
 
 // pub(crate) fn affine_transform(
-//     array: GeometryArrayEnum,
+//     array: GeometryArray,
 //     matrix: impl Into<AffineTransform<f64>>,
-// ) -> Result<GeometryArrayEnum> {
+// ) -> Result<GeometryArray> {
 //     let transform: AffineTransform<f64> = matrix.into();
 
 //     match array {
-//         GeometryArrayEnum::WKB(arr) => {
+//         GeometryArray::WKB(arr) => {
 //             let output_geoms: Vec<Option<Geometry>> = arr
 //                 .iter_geo()
 //                 .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
 //                 .collect();
 
-//             Ok(GeometryArrayEnum::WKB(output_geoms.into()))
+//             Ok(GeometryArray::WKB(output_geoms.into()))
 //         }
-//         GeometryArrayEnum::Point(arr) => {
+//         GeometryArray::Point(arr) => {
 //             let output_geoms: Vec<Option<Point>> = arr
 //                 .iter_geo()
 //                 .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
 //                 .collect();
 
-//             Ok(GeometryArrayEnum::Point(output_geoms.into()))
+//             Ok(GeometryArray::Point(output_geoms.into()))
 //         }
 
-//         GeometryArrayEnum::MultiPoint(arr) => {
+//         GeometryArray::MultiPoint(arr) => {
 //             let output_geoms: Vec<Option<MultiPoint>> = arr
 //                 .iter_geo()
 //                 .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
 //                 .collect();
 
-//             Ok(GeometryArrayEnum::MultiPoint(output_geoms.into()))
+//             Ok(GeometryArray::MultiPoint(output_geoms.into()))
 //         }
-//         GeometryArrayEnum::LineString(arr) => {
+//         GeometryArray::LineString(arr) => {
 //             let output_geoms: Vec<Option<LineString>> = arr
 //                 .iter_geo()
 //                 .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
 //                 .collect();
 
-//             Ok(GeometryArrayEnum::LineString(output_geoms.into()))
+//             Ok(GeometryArray::LineString(output_geoms.into()))
 //         }
-//         GeometryArrayEnum::MultiLineString(arr) => {
+//         GeometryArray::MultiLineString(arr) => {
 //             let output_geoms: Vec<Option<MultiLineString>> = arr
 //                 .iter_geo()
 //                 .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
 //                 .collect();
 
-//             Ok(GeometryArrayEnum::MultiLineString(output_geoms.into()))
+//             Ok(GeometryArray::MultiLineString(output_geoms.into()))
 //         }
-//         GeometryArrayEnum::Polygon(arr) => {
+//         GeometryArray::Polygon(arr) => {
 //             let output_geoms: Vec<Option<Polygon>> = arr
 //                 .iter_geo()
 //                 .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
 //                 .collect();
 
-//             Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+//             Ok(GeometryArray::Polygon(output_geoms.into()))
 //         }
-//         GeometryArrayEnum::MultiPolygon(arr) => {
+//         GeometryArray::MultiPolygon(arr) => {
 //             let output_geoms: Vec<Option<MultiPolygon>> = arr
 //                 .iter_geo()
 //                 .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
 //                 .collect();
 
-//             Ok(GeometryArrayEnum::MultiPolygon(output_geoms.into()))
+//             Ok(GeometryArray::MultiPolygon(output_geoms.into()))
 //         }
 //     }
 // }
 
-// // pub(crate) fn rotate(array: GeometryArrayEnum, angle: f64, origin: TransformOrigin) -> Result<GeometryArrayEnum> {
+// // pub(crate) fn rotate(array: GeometryArray, angle: f64, origin: TransformOrigin) -> Result<GeometryArray> {
 // //     match origin {
 // //         TransformOrigin::Centroid => {
 // //             let centroid_arr = centroid(array)?;

--- a/geopolars/geopolars-geo/src/ops/area.rs
+++ b/geopolars/geopolars-geo/src/ops/area.rs
@@ -1,37 +1,37 @@
 use crate::error::Result;
 use geo::prelude::Area;
-use geopolars_arrow::GeometryArrayEnum;
+use geopolars_arrow::{GeometryArray, GeometryArrayTrait};
 use polars::export::arrow::array::{MutablePrimitiveArray, PrimitiveArray};
 
-pub(crate) fn area(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
+pub(crate) fn area(array: GeometryArray) -> Result<PrimitiveArray<f64>> {
     let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(array.len());
 
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.unsigned_area())));
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.unsigned_area())));
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.unsigned_area())));
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.unsigned_area())));
         }
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::MultiPoint(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.unsigned_area())));
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.unsigned_area())));
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.unsigned_area())));
         }

--- a/geopolars/geopolars-geo/src/ops/centroid.rs
+++ b/geopolars/geopolars-geo/src/ops/centroid.rs
@@ -1,37 +1,37 @@
 use crate::error::Result;
 use geo::algorithm::centroid::Centroid;
 use geopolars_arrow::MutablePointArray;
-use geopolars_arrow::{GeometryArrayEnum, PointArray};
+use geopolars_arrow::{GeometryArray, GeometryArrayTrait, PointArray};
 
-pub(crate) fn centroid(array: GeometryArrayEnum) -> Result<PointArray> {
+pub(crate) fn centroid(array: GeometryArray) -> Result<PointArray> {
     let mut output_array = MutablePointArray::with_capacity(array.len());
 
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push_geo(maybe_g.and_then(|g| g.centroid())));
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push_geo(maybe_g.map(|g| g.centroid())));
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push_geo(maybe_g.and_then(|g| g.centroid())));
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push_geo(maybe_g.and_then(|g| g.centroid())));
         }
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::MultiPoint(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push_geo(maybe_g.and_then(|g| g.centroid())));
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push_geo(maybe_g.and_then(|g| g.centroid())));
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push_geo(maybe_g.and_then(|g| g.centroid())));
         }

--- a/geopolars/geopolars-geo/src/ops/convex_hull.rs
+++ b/geopolars/geopolars-geo/src/ops/convex_hull.rs
@@ -1,66 +1,66 @@
 use crate::error::Result;
 use geo::algorithm::convex_hull::ConvexHull;
 use geo::Polygon;
-use geopolars_arrow::GeometryArrayEnum;
+use geopolars_arrow::GeometryArray;
 
-pub(crate) fn convex_hull(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
+pub(crate) fn convex_hull(array: GeometryArray) -> Result<GeometryArray> {
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
 
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::MultiPoint(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
     }
 }
@@ -69,7 +69,7 @@ pub(crate) fn convex_hull(array: GeometryArrayEnum) -> Result<GeometryArrayEnum>
 mod tests {
     use super::convex_hull;
     use geo::{line_string, polygon, Geometry, MultiPoint, Point};
-    use geopolars_arrow::{GeometryArrayEnum, LineStringArray, MultiPointArray};
+    use geopolars_arrow::{GeometryArray, GeometryArrayTrait, LineStringArray, MultiPointArray};
 
     #[test]
     fn convex_hull_for_multipoint() {
@@ -87,7 +87,7 @@ mod tests {
         ]
         .into();
         let input_array: MultiPointArray = vec![input_geom].into();
-        let result_array = convex_hull(GeometryArrayEnum::MultiPoint(input_array)).unwrap();
+        let result_array = convex_hull(GeometryArray::MultiPoint(input_array)).unwrap();
 
         let expected = polygon![
             (x:0.0, y: -10.0),
@@ -118,7 +118,7 @@ mod tests {
         ];
 
         let input_array: LineStringArray = vec![input_geom].into();
-        let result_array = convex_hull(GeometryArrayEnum::LineString(input_array)).unwrap();
+        let result_array = convex_hull(GeometryArray::LineString(input_array)).unwrap();
 
         let expected = polygon![
             (x: 0.0, y: -10.0),

--- a/geopolars/geopolars-geo/src/ops/envelope.rs
+++ b/geopolars/geopolars-geo/src/ops/envelope.rs
@@ -1,11 +1,11 @@
 use crate::error::Result;
 use geo::algorithm::bounding_rect::BoundingRect;
 use geo::Polygon;
-use geopolars_arrow::GeometryArrayEnum;
+use geopolars_arrow::GeometryArray;
 
-pub(crate) fn envelope(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
+pub(crate) fn envelope(array: GeometryArray) -> Result<GeometryArray> {
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| {
@@ -13,10 +13,10 @@ pub(crate) fn envelope(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
                 })
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::Point(arr) => Ok(GeometryArrayEnum::Point(arr)),
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::Point(arr) => Ok(GeometryArray::Point(arr)),
+        GeometryArray::MultiPoint(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| {
@@ -24,9 +24,9 @@ pub(crate) fn envelope(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
                 })
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| {
@@ -34,9 +34,9 @@ pub(crate) fn envelope(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
                 })
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| {
@@ -44,9 +44,9 @@ pub(crate) fn envelope(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
                 })
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| {
@@ -54,9 +54,9 @@ pub(crate) fn envelope(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
                 })
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| {
@@ -64,7 +64,7 @@ pub(crate) fn envelope(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
                 })
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
     }
 }

--- a/geopolars/geopolars-geo/src/ops/explode.rs
+++ b/geopolars/geopolars-geo/src/ops/explode.rs
@@ -1,13 +1,13 @@
 use crate::error::Result;
 use geo::Geometry;
-use geopolars_arrow::{GeometryArrayEnum, WKBArray};
+use geopolars_arrow::{GeometryArray, WKBArray};
 
-pub(crate) fn explode(array: GeometryArrayEnum) -> Result<GeometryArrayEnum> {
+pub(crate) fn explode(array: GeometryArray) -> Result<GeometryArray> {
     match array {
-        GeometryArrayEnum::WKB(arr) => Ok(GeometryArrayEnum::WKB(explode_wkb(arr)?)),
-        GeometryArrayEnum::Point(arr) => Ok(GeometryArrayEnum::Point(arr)),
-        GeometryArrayEnum::LineString(arr) => Ok(GeometryArrayEnum::LineString(arr)),
-        GeometryArrayEnum::Polygon(arr) => Ok(GeometryArrayEnum::Polygon(arr)),
+        GeometryArray::WKB(arr) => Ok(GeometryArray::WKB(explode_wkb(arr)?)),
+        GeometryArray::Point(arr) => Ok(GeometryArray::Point(arr)),
+        GeometryArray::LineString(arr) => Ok(GeometryArray::LineString(arr)),
+        GeometryArray::Polygon(arr) => Ok(GeometryArray::Polygon(arr)),
         _ => todo!(),
     }
 }

--- a/geopolars/geopolars-geo/src/ops/is_empty.rs
+++ b/geopolars/geopolars-geo/src/ops/is_empty.rs
@@ -1,37 +1,37 @@
 use crate::error::Result;
 use geo::dimensions::HasDimensions;
-use geopolars_arrow::GeometryArrayEnum;
+use geopolars_arrow::{GeometryArray, GeometryArrayTrait};
 use polars::export::arrow::array::{BooleanArray, MutableBooleanArray};
 
-pub(crate) fn is_empty(array: GeometryArrayEnum) -> Result<BooleanArray> {
+pub(crate) fn is_empty(array: GeometryArray) -> Result<BooleanArray> {
     let mut output_array = MutableBooleanArray::with_capacity(array.len());
 
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.is_empty())));
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.is_empty())));
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.is_empty())));
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.is_empty())));
         }
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::MultiPoint(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.is_empty())));
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.is_empty())));
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.is_empty())));
         }

--- a/geopolars/geopolars-geo/src/ops/length.rs
+++ b/geopolars/geopolars-geo/src/ops/length.rs
@@ -4,7 +4,7 @@ use geo::algorithm::geodesic_length::GeodesicLength;
 use geo::algorithm::haversine_length::HaversineLength;
 use geo::algorithm::vincenty_length::VincentyLength;
 use geo::Geometry;
-use geopolars_arrow::GeometryArrayEnum;
+use geopolars_arrow::{GeometryArray, GeometryArrayTrait};
 use polars::error::ErrString;
 use polars::export::arrow::array::{MutablePrimitiveArray, PrimitiveArray};
 use polars::export::arrow::bitmap::Bitmap;
@@ -17,34 +17,34 @@ pub enum GeodesicLengthMethod {
     Vincenty,
 }
 
-pub(crate) fn euclidean_length(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
+pub(crate) fn euclidean_length(array: GeometryArray) -> Result<PrimitiveArray<f64>> {
     let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(array.len());
 
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(geometry_euclidean_length)));
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             return Ok(zero_arr(arr.len(), arr.validity()));
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.euclidean_length())));
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array.push(maybe_g.map(|g| g.exterior().euclidean_length()))
             });
         }
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::MultiPoint(arr) => {
             return Ok(zero_arr(arr.len(), arr.validity()));
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.euclidean_length())));
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array.push(maybe_g.map(|g| {
                     g.iter()
@@ -59,7 +59,7 @@ pub(crate) fn euclidean_length(array: GeometryArrayEnum) -> Result<PrimitiveArra
 }
 
 pub(crate) fn geodesic_length(
-    array: GeometryArrayEnum,
+    array: GeometryArray,
     method: &GeodesicLengthMethod,
 ) -> Result<PrimitiveArray<f64>> {
     match method {
@@ -69,34 +69,34 @@ pub(crate) fn geodesic_length(
     }
 }
 
-fn _geodesic_length(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
+fn _geodesic_length(array: GeometryArray) -> Result<PrimitiveArray<f64>> {
     let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(array.len());
 
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(geometry_geodesic_length)));
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             return Ok(zero_arr(arr.len(), arr.validity()));
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.geodesic_length())));
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array.push(maybe_g.map(|g| g.exterior().geodesic_length()))
             });
         }
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::MultiPoint(arr) => {
             return Ok(zero_arr(arr.len(), arr.validity()));
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.geodesic_length())));
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array.push(
                     maybe_g.map(|g| g.iter().map(|poly| poly.exterior().geodesic_length()).sum()),
@@ -108,34 +108,34 @@ fn _geodesic_length(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
     Ok(output_array.into())
 }
 
-fn haversine_length(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
+fn haversine_length(array: GeometryArray) -> Result<PrimitiveArray<f64>> {
     let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(array.len());
 
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(geometry_haversine_length)));
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             return Ok(zero_arr(arr.len(), arr.validity()));
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.haversine_length())));
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array.push(maybe_g.map(|g| g.exterior().haversine_length()))
             });
         }
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::MultiPoint(arr) => {
             return Ok(zero_arr(arr.len(), arr.validity()));
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.haversine_length())));
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array.push(maybe_g.map(|g| {
                     g.iter()
@@ -149,26 +149,26 @@ fn haversine_length(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
     Ok(output_array.into())
 }
 
-fn vincenty_length(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
+fn vincenty_length(array: GeometryArray) -> Result<PrimitiveArray<f64>> {
     let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(array.len());
     let map_vincenty_error =
         |_| PolarsError::ComputeError(ErrString::from("Failed to calculate vincenty length"));
 
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             arr.iter_geo()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(geometry_vincenty_length)));
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             return Ok(zero_arr(arr.len(), arr.validity()));
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array
                     .push(maybe_g.map(|g| g.vincenty_length().map_err(map_vincenty_error).unwrap()))
             });
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array.push(maybe_g.map(|g| {
                     g.exterior()
@@ -178,16 +178,16 @@ fn vincenty_length(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
                 }))
             });
         }
-        GeometryArrayEnum::MultiPoint(arr) => {
+        GeometryArray::MultiPoint(arr) => {
             return Ok(zero_arr(arr.len(), arr.validity()));
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array
                     .push(maybe_g.map(|g| g.vincenty_length().map_err(map_vincenty_error).unwrap()))
             });
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             arr.iter_geo().for_each(|maybe_g| {
                 output_array.push(maybe_g.map(|g| {
                     g.iter()
@@ -327,7 +327,7 @@ fn geometry_vincenty_length(geom: Geometry) -> f64 {
 mod tests {
     use super::{euclidean_length, geodesic_length, GeodesicLengthMethod};
     use geo::{line_string, Geometry};
-    use geopolars_arrow::{GeometryArrayEnum, LineStringArray, WKBArray};
+    use geopolars_arrow::{GeometryArray, LineStringArray, WKBArray};
     use polars::export::arrow::array::Array;
 
     #[test]
@@ -342,7 +342,7 @@ mod tests {
         ]
         .into();
         let input_array: WKBArray = vec![Some(input_geom)].into();
-        let result_array = euclidean_length(GeometryArrayEnum::WKB(input_array)).unwrap();
+        let result_array = euclidean_length(GeometryArray::WKB(input_array)).unwrap();
 
         let expected = 10.0_f64;
         assert_eq!(expected, result_array.value(0).round());
@@ -360,7 +360,7 @@ mod tests {
             (x: 11., y: 1.)
         ];
         let input_array: LineStringArray = vec![input_geom].into();
-        let result_array = euclidean_length(GeometryArrayEnum::LineString(input_array)).unwrap();
+        let result_array = euclidean_length(GeometryArray::LineString(input_array)).unwrap();
 
         let expected = 10.0_f64;
         assert_eq!(expected, result_array.value(0).round());
@@ -378,7 +378,7 @@ mod tests {
         .into();
         let input_array: WKBArray = vec![Some(input_geom)].into();
         let result_array = geodesic_length(
-            GeometryArrayEnum::WKB(input_array),
+            GeometryArray::WKB(input_array),
             &GeodesicLengthMethod::Haversine,
         )
         .unwrap();
@@ -399,7 +399,7 @@ mod tests {
         ];
         let input_array: LineStringArray = vec![input_geom].into();
         let result_array = geodesic_length(
-            GeometryArrayEnum::LineString(input_array),
+            GeometryArray::LineString(input_array),
             &GeodesicLengthMethod::Haversine,
         )
         .unwrap();
@@ -421,7 +421,7 @@ mod tests {
         .into();
         let input_array: WKBArray = vec![Some(input_geom)].into();
         let result_array = geodesic_length(
-            GeometryArrayEnum::WKB(input_array),
+            GeometryArray::WKB(input_array),
             &GeodesicLengthMethod::Vincenty,
         )
         .unwrap();
@@ -442,7 +442,7 @@ mod tests {
         ];
         let input_array: LineStringArray = vec![input_geom].into();
         let result_array = geodesic_length(
-            GeometryArrayEnum::LineString(input_array),
+            GeometryArray::LineString(input_array),
             &GeodesicLengthMethod::Vincenty,
         )
         .unwrap();
@@ -466,7 +466,7 @@ mod tests {
         .into();
         let input_array: WKBArray = vec![Some(input_geom)].into();
         let result_array = geodesic_length(
-            GeometryArrayEnum::WKB(input_array),
+            GeometryArray::WKB(input_array),
             &GeodesicLengthMethod::Geodesic,
         )
         .unwrap();
@@ -489,7 +489,7 @@ mod tests {
         ];
         let input_array: LineStringArray = vec![input_geom].into();
         let result_array = geodesic_length(
-            GeometryArrayEnum::LineString(input_array),
+            GeometryArray::LineString(input_array),
             &GeodesicLengthMethod::Geodesic,
         )
         .unwrap();

--- a/geopolars/geopolars-geo/src/ops/point.rs
+++ b/geopolars/geopolars-geo/src/ops/point.rs
@@ -1,17 +1,17 @@
 use crate::error::Result;
 use geo::Geometry;
-use geopolars_arrow::GeometryArrayEnum;
+use geopolars_arrow::{GeometryArray, GeometryArrayTrait};
 use polars::export::arrow::array::{MutablePrimitiveArray, PrimitiveArray};
 use polars::export::arrow::datatypes::DataType;
 
-pub(crate) fn x(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
+pub(crate) fn x(array: GeometryArray) -> Result<PrimitiveArray<f64>> {
     match array {
-        GeometryArrayEnum::Point(arr) => Ok(PrimitiveArray::<f64>::new(
+        GeometryArray::Point(arr) => Ok(PrimitiveArray::<f64>::new(
             DataType::Float64,
             arr.values_x().clone(),
             arr.validity().cloned(),
         )),
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             let mut output_arr = MutablePrimitiveArray::<f64>::with_capacity(arr.len());
             arr.iter_geo().for_each(|maybe_geom| {
                 let maybe_point = maybe_geom.map(|geom| match geom {
@@ -26,14 +26,14 @@ pub(crate) fn x(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
     }
 }
 
-pub(crate) fn y(array: GeometryArrayEnum) -> Result<PrimitiveArray<f64>> {
+pub(crate) fn y(array: GeometryArray) -> Result<PrimitiveArray<f64>> {
     match array {
-        GeometryArrayEnum::Point(arr) => Ok(PrimitiveArray::<f64>::new(
+        GeometryArray::Point(arr) => Ok(PrimitiveArray::<f64>::new(
             DataType::Float64,
             arr.values_y().clone(),
             arr.validity().cloned(),
         )),
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             let mut output_arr = MutablePrimitiveArray::<f64>::with_capacity(arr.len());
             arr.iter_geo().for_each(|maybe_geom| {
                 let maybe_point = maybe_geom.map(|geom| match geom {

--- a/geopolars/geopolars-geo/src/ops/simplify.rs
+++ b/geopolars/geopolars-geo/src/ops/simplify.rs
@@ -1,51 +1,51 @@
 use crate::error::Result;
 use geo::algorithm::simplify::Simplify;
 use geo::{Geometry, LineString, MultiLineString, MultiPolygon, Polygon};
-use geopolars_arrow::GeometryArrayEnum;
+use geopolars_arrow::GeometryArray;
 
-pub(crate) fn simplify(array: GeometryArrayEnum, tolerance: &f64) -> Result<GeometryArrayEnum> {
+pub(crate) fn simplify(array: GeometryArray, tolerance: &f64) -> Result<GeometryArray> {
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             let output_geoms: Vec<Option<Geometry>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| simplify_geometry(geom, tolerance)))
                 .collect();
 
-            Ok(GeometryArrayEnum::WKB(output_geoms.into()))
+            Ok(GeometryArray::WKB(output_geoms.into()))
         }
-        GeometryArrayEnum::Point(arr) => Ok(GeometryArrayEnum::Point(arr)),
-        GeometryArrayEnum::MultiPoint(arr) => Ok(GeometryArrayEnum::MultiPoint(arr)),
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::Point(arr) => Ok(GeometryArray::Point(arr)),
+        GeometryArray::MultiPoint(arr) => Ok(GeometryArray::MultiPoint(arr)),
+        GeometryArray::LineString(arr) => {
             let output_geoms: Vec<Option<LineString>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.simplify(tolerance)))
                 .collect();
 
-            Ok(GeometryArrayEnum::LineString(output_geoms.into()))
+            Ok(GeometryArray::LineString(output_geoms.into()))
         }
-        GeometryArrayEnum::MultiLineString(arr) => {
+        GeometryArray::MultiLineString(arr) => {
             let output_geoms: Vec<Option<MultiLineString>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.simplify(tolerance)))
                 .collect();
 
-            Ok(GeometryArrayEnum::MultiLineString(output_geoms.into()))
+            Ok(GeometryArray::MultiLineString(output_geoms.into()))
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             let output_geoms: Vec<Option<Polygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.simplify(tolerance)))
                 .collect();
 
-            Ok(GeometryArrayEnum::Polygon(output_geoms.into()))
+            Ok(GeometryArray::Polygon(output_geoms.into()))
         }
-        GeometryArrayEnum::MultiPolygon(arr) => {
+        GeometryArray::MultiPolygon(arr) => {
             let output_geoms: Vec<Option<MultiPolygon>> = arr
                 .iter_geo()
                 .map(|maybe_g| maybe_g.map(|geom| geom.simplify(tolerance)))
                 .collect();
 
-            Ok(GeometryArrayEnum::MultiPolygon(output_geoms.into()))
+            Ok(GeometryArray::MultiPolygon(output_geoms.into()))
         }
     }
 }
@@ -66,7 +66,7 @@ fn simplify_geometry(geom: Geometry, tolerance: &f64) -> Geometry {
 mod tests {
     use super::simplify;
     use geo::{line_string, polygon, Geometry};
-    use geopolars_arrow::{GeometryArrayEnum, LineStringArray, PolygonArray};
+    use geopolars_arrow::{GeometryArray, GeometryArrayTrait, LineStringArray, PolygonArray};
 
     #[test]
     fn rdp_test() {
@@ -78,7 +78,7 @@ mod tests {
             (x: 27.8, y: 0.1 ),
         ];
         let input_array: LineStringArray = vec![input_geom].into();
-        let result_array = simplify(GeometryArrayEnum::LineString(input_array), &1.0).unwrap();
+        let result_array = simplify(GeometryArray::LineString(input_array), &1.0).unwrap();
 
         let expected = line_string![
             ( x: 0.0, y: 0.0 ),
@@ -104,7 +104,7 @@ mod tests {
             (x: 0., y: 0.),
         ];
         let input_array: PolygonArray = vec![input_geom].into();
-        let result_array = simplify(GeometryArrayEnum::Polygon(input_array), &2.0).unwrap();
+        let result_array = simplify(GeometryArray::Polygon(input_array), &2.0).unwrap();
 
         let expected = polygon![
             (x: 0., y: 0.),

--- a/geopolars/geopolars-geos/src/ops/area.rs
+++ b/geopolars/geopolars-geos/src/ops/area.rs
@@ -1,36 +1,36 @@
-use geopolars_arrow::GeometryArrayEnum;
+use geopolars_arrow::{GeometryArray, GeometryArrayTrait};
 use geos::Geom;
 use polars::export::arrow::array::{MutablePrimitiveArray, PrimitiveArray};
 
-pub fn area(array: GeometryArrayEnum) -> PrimitiveArray<f64> {
+pub fn area(array: GeometryArray) -> PrimitiveArray<f64> {
     let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(array.len());
 
     match array {
-        GeometryArrayEnum::WKB(arr) => {
+        GeometryArray::WKB(arr) => {
             arr.iter_geos()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.area().unwrap())));
         }
-        GeometryArrayEnum::Point(arr) => {
+        GeometryArray::Point(arr) => {
             arr.iter_geos()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.area().unwrap())));
         }
-        GeometryArrayEnum::LineString(arr) => {
+        GeometryArray::LineString(arr) => {
             arr.iter_geos()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.area().unwrap())));
         }
-        GeometryArrayEnum::Polygon(arr) => {
+        GeometryArray::Polygon(arr) => {
             arr.iter_geos()
                 .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.area().unwrap())));
         }
-        // GeometryArrayEnum::MultiPoint(arr) => {
+        // GeometryArray::MultiPoint(arr) => {
         //     arr.iter_geos()
         //         .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.area().unwrap())));
         // }
-        // GeometryArrayEnum::MultiLineString(arr) => {
+        // GeometryArray::MultiLineString(arr) => {
         //     arr.iter_geos()
         //         .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.area().unwrap())));
         // }
-        // GeometryArrayEnum::MultiPolygon(arr) => {
+        // GeometryArray::MultiPolygon(arr) => {
         //     arr.iter_geos()
         //         .for_each(|maybe_g| output_array.push(maybe_g.map(|g| g.area().unwrap())));
         // }
@@ -46,7 +46,7 @@ mod tests {
     use approx::assert_relative_eq;
     use geo::{polygon, Polygon};
     use geopolars_arrow::polygon::MutablePolygonArray;
-    use geopolars_arrow::{GeometryArrayEnum, PolygonArray};
+    use geopolars_arrow::{GeometryArray, PolygonArray};
     use polars::export::arrow::array::{Array, PrimitiveArray};
 
     fn call_area(input: Vec<Polygon>) -> PrimitiveArray<f64> {
@@ -55,7 +55,7 @@ mod tests {
 
         let polygon_arr2: PolygonArray = polygon_arr.try_into().unwrap();
 
-        let result = area(GeometryArrayEnum::Polygon(polygon_arr2));
+        let result = area(GeometryArray::Polygon(polygon_arr2));
         let result_arr = result
             .as_any()
             .downcast_ref::<PrimitiveArray<f64>>()


### PR DESCRIPTION
- Implement `From<Scalar> for geo::Geometry`
- Update `GeometryArrayTrait` to not be a trait object and move functionality to taht
- Implement `GeometryArrayTrait` for everything
- Rename `GeometryArrayEnum` to `GeometryArray`
- Rename `GeometryArray` to `GeometryArrayTrait`
- Blanket trait implementations for `get`, `value_as_geo` and `get_as_geo`