### PR TITLE
Update wheel build for poetry

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -262,7 +262,7 @@ jobs:
         shell: bash
         run: |
           export PKG_CONFIG_PATH="$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/lib/pkgconfig"
-          maturin build --release --strip --interpreter python -o wheels-pre-repair --features proj
+          poetry run maturin build --release --strip --interpreter python -o wheels-pre-repair --features proj
 
       - name: Repair wheel
         shell: bash

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -35,8 +35,6 @@ jobs:
           poetry install
           apt update
           echo "after update"
-          apt install -y libgdal-dev
-          echo "after libgdal"
           apt install -y clang-7
 
       - name: Compile PROJ

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -3,8 +3,8 @@ name: Build Python Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    tags:
-      - "v*"
+    # tags:
+    #   - "v*"
 
 env:
   PROJ_VERSION: "9.1.0"
@@ -30,7 +30,9 @@ jobs:
       - name: Install dependencies
         run: |
           export PATH="/opt/python/cp38-cp38/bin/:$PATH"
-          pip install -r build.requirements.txt
+          pip install -U pip
+          pip install poetry
+          poetry install
           apt update
           apt install -y libgdal-dev clang-7
 
@@ -57,7 +59,7 @@ jobs:
         run: |
           source $HOME/.cargo/env
           export PATH="/opt/python/cp38-cp38/bin/:$PATH"
-          maturin build --release --strip --interpreter /opt/python/cp38-cp38/bin/python --manylinux 2_24 -o wheels --features proj
+          poetry run maturin build --release --strip --interpreter /opt/python/cp38-cp38/bin/python --manylinux 2_24 -o wheels --features proj
 
       - name: List wheels
         run: find ./wheels
@@ -87,8 +89,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-          cache: "pip"
-          cache-dependency-path: "py-geopolars/build.requirements.txt"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
 
       - name: Install system dependencies
         run: |
@@ -103,13 +110,11 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -V
-          pip install wheel
-          pip install --upgrade pip
-          pip install -r build.requirements.txt
+          poetry install
 
       - name: Build
         run: |
-          maturin build --release --strip --interpreter python -o wheels --features proj
+          poetry run maturin build --release --strip --interpreter python -o wheels --features proj
 
       - name: List wheels
         run: find ./wheels
@@ -142,28 +147,32 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-          cache: "pip"
-          cache-dependency-path: "py-geopolars/build.requirements.txt"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
 
       - name: Install system dependencies
         run: |
           brew install proj
           brew info proj
+
       - name: Copy PROJ_DATA into current tree
         run: |
-          python scripts/copy-proj-data.py
+          poetry run python scripts/copy-proj-data.py
           find python/geopolars/proj_data/
 
       - name: Install Python dependencies
         run: |
           python -V
-          pip install wheel
-          pip install --upgrade pip
-          pip install -r build.requirements.txt
+          poetry install
 
       - name: Build
         run: |
-          maturin build --release --target aarch64-apple-darwin --strip --interpreter python -o wheels --features proj
+          poetry run maturin build --release --target aarch64-apple-darwin --strip --interpreter python -o wheels --features proj
 
       - name: List wheels
         run: find ./wheels
@@ -291,6 +300,8 @@ jobs:
           pip install -U build
           cd py-geopolars && python -m build --sdist
 
+      # Have to set path from root
+      # https://github.com/actions/upload-artifact/issues/232#issuecomment-964235360
       - uses: actions/upload-artifact@v2
         with:
           path: py-geopolars/dist/*.tar.gz

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -13,7 +13,7 @@ jobs:
   build-wheel-manylinux-2-24:
     name: "Build manylinux 2.24 wheels"
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_24_x86_64
+    container: quay.io/pypa/manylinux2014_x86_64
     defaults:
       run:
         working-directory: py-geopolars
@@ -33,9 +33,7 @@ jobs:
           pip install -U pip
           pip install poetry
           poetry install
-          apt update
-          echo "after update"
-          apt install -y clang-7
+          yum update
 
       - name: Compile PROJ
         run: |
@@ -44,7 +42,6 @@ jobs:
           export PROJ_VERSION=${{ env.PROJ_VERSION }}
           export PKG_CONFIG_PATH="/project/pyproj/proj_dir/lib/pkgconfig/:$PKG_CONFIG_PATH"
           export PROJ_DIR=/project/pyproj/proj_dir
-          export MB_ML_VER=_2_24
 
           bash ./ci/proj-compile-wheels.sh
           find /project/pyproj/proj_dir

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -224,9 +224,8 @@ jobs:
         shell: bash
         run: |
           python -V
-          python -m pip install wheel
-          python -m pip install --upgrade pip
-          python -m pip install -r build.requirements.txt
+          python -m pip install poetry
+          poetry install
           python -m pip install delvewheel
 
       - name: Cache vcpkg

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -3,8 +3,8 @@ name: Build Python Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    # tags:
-    #   - "v*"
+    tags:
+      - "v*"
 
 env:
   PROJ_VERSION: "9.1.0"

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -10,8 +10,8 @@ env:
   PROJ_VERSION: "9.1.0"
 
 jobs:
-  build-wheel-manylinux-2-24:
-    name: "Build manylinux 2.24 wheels"
+  build-wheel-manylinux2014:
+    name: "Build manylinux2014 wheels"
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
     defaults:
@@ -57,7 +57,9 @@ jobs:
         run: |
           source $HOME/.cargo/env
           export PATH="/opt/python/cp38-cp38/bin/:$PATH"
-          poetry run maturin build --release --strip --interpreter /opt/python/cp38-cp38/bin/python --manylinux 2_24 -o wheels --features proj
+          poetry run maturin build --release --strip --interpreter /opt/python/cp38-cp38/bin/python --manylinux 2014 -o wheels
+          # TODO: restore proj feature. Unclear why pkg-config isn't picking up the proj version we built above
+          # --features proj
 
       - name: List wheels
         run: find ./wheels
@@ -306,7 +308,7 @@ jobs:
   upload_pypi:
     needs:
       [
-        build-wheel-manylinux-2-24,
+        build-wheel-manylinux2014,
         build-wheel-mac-x86_64,
         build-wheel-mac-aarch64,
         build-wheel-windows,

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -34,7 +34,10 @@ jobs:
           pip install poetry
           poetry install
           apt update
-          apt install -y libgdal-dev clang-7
+          echo "after update"
+          apt install -y libgdal-dev
+          echo "after libgdal"
+          apt install -y clang-7
 
       - name: Compile PROJ
         run: |


### PR DESCRIPTION
I noticed in https://github.com/geopolars/geopolars/pull/225 that the wheel builds were already failing because we switched the python build to Poetry in https://github.com/geopolars/geopolars/pull/216 but the wheel build was still trying to install from `build.requirements.txt`